### PR TITLE
Enlever le mot "Facebook" de la case [Remarques diverses] dans la fic…

### DIFF
--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -233,10 +233,7 @@ ActiveAdmin.register ChildSupport do
                 f.input "call#{call_idx}_notes",
                   input_html: {
                     rows: 8,
-                    style: "width: 70%",
-                    value: f.object.send("call#{call_idx}_notes").presence ||
-                      I18n.t("child_support.default.call_notes")
-
+                    style: "width: 70%"
                   }
                 if call_idx == 1
                   f.input :books_quantity, as: :radio, collection: child_support_books_quantity


### PR DESCRIPTION
https://trello.com/c/dVhphD3H/153-enlever-le-mot-facebook-de-la-case-remarques-diverses-dans-la-fiche-dappel-par-camille-bellier