### PR TITLE
Ajout d'un onglet "Notes" à la fiche de suivi

### DIFF
--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -298,13 +298,16 @@ ActiveAdmin.register ChildSupport do
             render "admin/events/history", events: f.object.parent_events.order(occurred_at: :desc).decorate
           end
         end
+        tab "Notes" do
+          f.input :notes, as: :text
+        end
       end
     end
     f.actions
   end
 
   base_attributes = %i[
-    important_information supporter_id should_be_read is_bilingual second_language to_call books_quantity
+    important_information supporter_id should_be_read is_bilingual second_language to_call books_quantity notes
   ] + [tags_params] + [{book_not_received: [], present_on: [], follow_us_on: []}]
   parent_attributes = %i[
     id
@@ -389,6 +392,11 @@ ActiveAdmin.register ChildSupport do
       if resource.first_child
         tab "Historique" do
           render "admin/events/history", events: resource.parent_events.order(occurred_at: :desc).decorate
+        end
+      end
+      tab "Notes" do
+        attributes_table title: "Notes" do
+          row :notes
         end
       end
     end

--- a/db/migrate/20211011124230_add_notes_to_child_support.rb
+++ b/db/migrate/20211011124230_add_notes_to_child_support.rb
@@ -1,0 +1,5 @@
+class AddNotesToChildSupport < ActiveRecord::Migration[6.0]
+  def change
+    add_column :child_supports, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_05_105530) do
+ActiveRecord::Schema.define(version: 2021_10_11_124230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2021_08_05_105530) do
     t.string "books_quantity"
     t.string "present_on"
     t.string "follow_us_on"
+    t.text "notes"
     t.index ["book_not_received"], name: "index_child_supports_on_book_not_received"
     t.index ["call1_parent_progress"], name: "index_child_supports_on_call1_parent_progress"
     t.index ["call1_reading_frequency"], name: "index_child_supports_on_call1_reading_frequency"


### PR DESCRIPTION
Ajouter un onglet "Notes" en simple champs libre, à la suite des onglets des différents appels, permettrait de pouvoir prendre des notes pour tout appel ou échange avec la famille hors parcours habituel.