### PR TITLE
fix: should not contact parent who send stop

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -43,9 +43,14 @@ class EventsController < ApplicationController
     head :unprocessable_entity and return unless event.save
 
     parent.children.where.not(group_id: nil).where(group_status: %w[active paused]).each do |child|
-      child.group_status = "stopped"
-      child.group_end = Time.now
-      child.save(validate: false)
+      if child.parent2
+        child.parent1 == parent ? child.should_contact_parent1 = false : child.should_contact_parent2 = false
+      else
+        child.group_status = "stopped"
+        child.group_end = Time.now
+        child.save(validate: false)
+      end
+
     end
 
     head :ok


### PR DESCRIPTION
il faudrait plutôt que ça fonctionne comme ça :
- s'il y a deux parents "à contacter" et que parent X envoie STOP -> parent X passe en ne pas contacter mais la cohorte reste active (il y a encore un parent à contacter)
- s'il y a un seul parent "à contacter" et que le parent envoie STOP, la cohorte est arrêtée