### PR TITLE
fix: Adding pmi_detail to siblings at creation

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -134,6 +134,7 @@ class ChildrenController < ApplicationController
           land: @child.land,
           should_contact_parent1: @child.should_contact_parent1,
           should_contact_parent2: @child.should_contact_parent2,
+          pmi_detail: @child.pmi_detail,
           child_support: @child.child_support
         ))
       end


### PR DESCRIPTION
https://airtable.com/appmi74ySFQorEQTS/tblRouCP9gch27sQU/viwBiBSsDt3IoWxFz/recK8PAYu3IQDs9mv?blocks=hide