### PR TITLE
Mise à jour du 20 Mai

### DIFF
--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -559,6 +559,8 @@ ActiveAdmin.register Child do
     column :group_status
 
     column :family_text_messages_count
+    column :family_text_messages_received_count
+    column :family_text_messages_sent_count
 
     column :family_redirection_urls_count
     column :family_redirection_url_visits_count

--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -480,7 +480,11 @@ ActiveAdmin.register Child do
   end
 
   collection_action :set_age_ok do
-    child_with_age_ok = Child.where(birthdate: Date.new(Date.today.year - 2, 1, 1)..Date.new(Date.today.year, 12, 31))
+    child_with_age_ok = if Date.today.month <= 8
+                          Child.where(birthdate: Date.new(Date.today.year - 3, 1, 1)..Date.new(Date.today.year, 12, 31))
+                        else
+                          Child.where(birthdate: Date.new(Date.today.year - 2, 1, 1)..Date.new(Date.today.year, 12, 31))
+                        end
 
     Child.all.each do |child|
       if child_with_age_ok.include? child

--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -528,6 +528,7 @@ ActiveAdmin.register ChildSupport do
     end
 
     column :tag_list
+    column :notes
 
     column :created_at
     column :updated_at

--- a/app/decorators/child_decorator.rb
+++ b/app/decorators/child_decorator.rb
@@ -179,6 +179,14 @@ class ChildDecorator < BaseDecorator
     model.family_text_messages.kept.count
   end
 
+  def family_text_messages_received_count
+    model.family_text_messages_received.kept.count
+  end
+
+  def family_text_messages_sent_count
+    model.family_text_messages_sent.kept.count
+  end
+
   def full_address
     model.parent1.decorate.full_address
   end
@@ -193,6 +201,8 @@ class ChildDecorator < BaseDecorator
   end
 
   def registration_months_range
+    return unless registration_months
+
     if registration_months >= 36
       "Plus de 36 mois"
     elsif registration_months >= 24

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -433,6 +433,14 @@ class Child < ApplicationRecord
     parent_events.text_messages
   end
 
+  def family_text_messages_received
+    parent_events.text_messages_send_by_app
+  end
+
+  def family_text_messages_sent
+    parent_events.text_messages_send_by_parent
+  end
+
   def update_counters!
     self.family_redirection_urls_count = family_redirection_urls.count("DISTINCT redirection_target_id")
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -78,6 +78,8 @@ class Event < ApplicationRecord
   scope :other_events, -> { where(type: "Events::OtherEvent") }
   scope :survey_responses, -> { where(type: "Events::SurveyResponse") }
   scope :text_messages, -> { where(type: "Events::TextMessage") }
+  scope :text_messages_send_by_app, -> { where(type: "Events::TextMessage", originated_by_app: true) }
+  scope :text_messages_send_by_parent, -> { where(type: "Events::TextMessage", originated_by_app: false) }
   scope :sent_by_app_text_messages, -> { where(type: "Events::TextMessage", originated_by_app: true) }
   scope :received_text_messages, -> { where(type: "Events::TextMessage", originated_by_app: false) }
   scope :workshop_participations, -> { where(type: "Events::WorkshopParticipation") }

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -72,6 +72,8 @@ fr:
         family_redirection_urls_count: URL courtes familiales
         family_redirection_visit_rate: "Taux de visites familiales d'URL courtes"
         family_text_messages_count: SMS familiaux
+        text_messages_received_count: SMS familiaux reçus
+        text_messages_sent_count: SMS familiaux envoyés
         first_name: Prénom
         group_end: Fin du suivi
         group_start: Debut du suivi
@@ -412,6 +414,8 @@ fr:
         redirection_visit_rate: "Taux de visites d'URL courtes"
         terms_accepted_at: Acceptation des conditions d'utilisation
         text_messages_count: SMS
+        text_messages_received_count: SMS reçus
+        text_messages_sent_count: SMS envoyés
       parent/gender:
         f: Femme
         m: Homme

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -72,8 +72,8 @@ fr:
         family_redirection_urls_count: URL courtes familiales
         family_redirection_visit_rate: "Taux de visites familiales d'URL courtes"
         family_text_messages_count: SMS familiaux
-        text_messages_received_count: SMS familiaux reçus
-        text_messages_sent_count: SMS familiaux envoyés
+        family_text_messages_received_count: SMS familiaux reçus
+        family_text_messages_sent_count: SMS familiaux envoyés
         first_name: Prénom
         group_end: Fin du suivi
         group_start: Debut du suivi
@@ -413,8 +413,6 @@ fr:
         redirection_urls_count: URL courtes
         redirection_visit_rate: "Taux de visites d'URL courtes"
         terms_accepted_at: Acceptation des conditions d'utilisation
-        text_messages_count: SMS
-        text_messages_received_count: SMS reçus
         text_messages_sent_count: SMS envoyés
       parent/gender:
         f: Femme


### PR DESCRIPTION
- Bug dans le compte des "SMS familiaux"
- Automatisation tag "enfant pas à l'école" + bouton de mise à jour
- Contenu de l'onglet "Notes" à ajouter dans l'export CSV de la fiche de suivi