### PR TITLE
fix: detect correctly if parents already worked with us

### DIFF
--- a/app/services/typeform/initial_form_service.rb
+++ b/app/services/typeform/initial_form_service.rb
@@ -138,7 +138,7 @@ module Typeform
       informations = []
       informations << @child_support.important_information if @child_support.important_information
       informations << "Nombre d'enfants: #{@data[:child_count]}" if @data[:child_count]
-      informations << "À déjà été accompagné par 1001 mots" if @data[:already_working_with]
+      informations << "À déjà été accompagné par 1001 mots" if @data[:already_working_with] == "Oui"
       informations << "#{@data[:most_present_parent]}" if @data[:most_present_parent]
       @child_support.important_information = informations.join("\n")
 


### PR DESCRIPTION
Description de l'erreur:
Pour savoir si un parent avait déjà travailler avec 1001mots, on vérifiait si le champ correspondant était présent dans la requete du webhook typeform. Or ce champ eput être a `nil` `Oui` ou `Non', quand c'était a non, on détéctais une valeur et considérais que c'était oui.

Fix:
Vérifier que la requete du webhook typeform contient bien 'Oui' dans le champ de réponse.