### PR TITLE
feature: conditionner l'envoi du choix de modules au fait que le parent ait des modules disponibles

### DIFF
--- a/app/services/child_support/select_module_service.rb
+++ b/app/services/child_support/select_module_service.rb
@@ -24,6 +24,8 @@ class ChildSupport::SelectModuleService
   private
 
   def send_select_module_message(parent, available_support_module_list)
+    return if available_support_module_list.reject(&:blank?).empty?
+
     @child_support_module = ChildrenSupportModule.create!(child_id: @child.id, parent_id: parent.id, available_support_module_list: available_support_module_list)
 
     selection_link = Rails.application.routes.url_helpers.edit_children_support_module_url(


### PR DESCRIPTION
La fonctionnalités de choix de module qui est à présent en prod a l'air de bien fonctionner et certains parents ont déjà répondu. Cependant, l'envoi automatique après la mise en statut "KO" semble concerner tous les appels et pas seulement les appels V2, ce qui veut dire que s'il ya eu des appels V1 KO ces 3 derniers jours, les parents ont reçu un choix de module qui n'aura aucun effet !
Un fix possible serait peut être de conditionner l'envoi du choix de modules au fait que le parent ait des modules disponibles