### PR TITLE
Mise en prod 6 janvier

### DIFF
--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -133,7 +133,7 @@ ActiveAdmin.register ChildSupport do
       child_support.supporter_id = supporter_id
       child_support.save!
     end
-    redirect_to admin_child_supports_path, notice: "Responsable mis à jour"
+    redirect_to request.referer, notice: "Responsable mis à jour"
   end
 
   batch_action :remove_book_not_received do |ids|

--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -133,7 +133,7 @@ ActiveAdmin.register ChildSupport do
       child_support.supporter_id = supporter_id
       child_support.save!
     end
-    redirect_to request.referer, notice: "Responsable mis à jour"
+    redirect_to admin_child_supports_path(Rack::Utils.parse_query URI(request.referer).query), notice: "Responsable mis à jour"
   end
 
   batch_action :remove_book_not_received do |ids|

--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -133,7 +133,7 @@ ActiveAdmin.register ChildSupport do
       child_support.supporter_id = supporter_id
       child_support.save!
     end
-    redirect_to admin_child_supports_path(Rack::Utils.parse_query URI(request.referer).query), notice: "Responsable mis à jour"
+    redirect_to admin_child_supports_path, notice: "Responsable mis à jour"
   end
 
   batch_action :remove_book_not_received do |ids|

--- a/app/admin/children_support_module.rb
+++ b/app/admin/children_support_module.rb
@@ -45,7 +45,16 @@ ActiveAdmin.register ChildrenSupportModule do
     f.actions
   end
 
-  permit_params :child_id, :parent_id, :support_module_id
+  permit_params :child_id, :parent_id, :support_module_id, :is_completed
+
+  scope :all, default: true
+
+  scope :with_support_module, group: :support_module_choice
+  scope :with_the_choice_to_make_by_us, group: :support_module_choice
+  scope :without_choice, group: :support_module_choice
+
+  scope :programmed, group: :programming
+  scope :not_programmed, group: :programming
 
   filter :is_completed, as: :boolean
   filter :is_programmed, as: :boolean

--- a/app/controllers/children_support_modules_controller.rb
+++ b/app/controllers/children_support_modules_controller.rb
@@ -5,7 +5,7 @@ class ChildrenSupportModulesController < ApplicationController
   def edit
     @support_modules = @children_support_module.available_support_modules
 
-    @action_path = children_support_module_path(@children_support_module, security_code: @children_support_module.parent.security_code)
+    @action_path = children_support_module_path(@children_support_module, sc: @children_support_module.parent.security_code)
   end
 
   def update
@@ -15,6 +15,8 @@ class ChildrenSupportModulesController < ApplicationController
     if @children_support_module.update(children_support_module_params)
       redirect_to updated_children_support_modules_path(child_first_name: @children_support_module.child.first_name )
     else
+      @support_modules = @children_support_module.available_support_modules
+      @action_path = children_support_module_path(@children_support_module, sc: @children_support_module.parent.security_code)
       render action: :edit
     end
   end
@@ -30,8 +32,9 @@ class ChildrenSupportModulesController < ApplicationController
   end
 
   def find_children_support_module
+    @security_code = params[:sc] || params[:security_code]
     @children_support_module = ChildrenSupportModule.find_by(id: params[:id])
     not_found and return if @children_support_module.nil?
-    not_found and return if @children_support_module.parent.security_code != params[:security_code]
+    not_found and return if @children_support_module.parent.security_code != @security_code
   end
 end

--- a/app/decorators/children_support_module_decorator.rb
+++ b/app/decorators/children_support_module_decorator.rb
@@ -1,15 +1,18 @@
 class ChildrenSupportModuleDecorator < BaseDecorator
 
-  def group
-    child.group&.name
+  def name
+    return support_module.decorate&.admin_link if support_module
+    return "Laisse le choix à 1001mots" if is_completed
+
+    "Pas encore choisi"
   end
 
   def parent_name
-    parent.decorate.name
+    parent.decorate.admin_link
   end
 
   def child_name
-    child.decorate.name
+    child.decorate.admin_link
   end
 
   def name_with_date
@@ -20,7 +23,7 @@ class ChildrenSupportModuleDecorator < BaseDecorator
   end
 
   def available_support_module_names
-    model.available_support_modules.pluck(:name)
+    model.available_support_modules.map { |support| support.decorate&.admin_link }
   end
 
 end

--- a/app/decorators/parent_decorator.rb
+++ b/app/decorators/parent_decorator.rb
@@ -122,7 +122,7 @@ class ParentDecorator < BaseDecorator
 
   def selected_support_module
     arbre do
-      model.children_support_modules.includes(:support_module).each do |children_support_module|
+      model.children_support_modules.includes(:support_module).decorate.each do |children_support_module|
         div do
           a "#{children_support_module.name} - #{children_support_module.created_at.strftime("%d/%m/%Y")}", href: admin_children_support_module_path(children_support_module),
             class: 'available_support_module', target: '_blank'

--- a/app/models/children_support_module.rb
+++ b/app/models/children_support_module.rb
@@ -30,17 +30,13 @@ class ChildrenSupportModule < ApplicationRecord
   belongs_to :support_module, optional: true
 
   scope :not_programmed, -> { where(is_programmed: false) }
+  scope :programmed, -> { where(is_programmed: true) }
   scope :with_support_module, -> { joins(:support_module) }
+  scope :with_the_choice_to_make_by_us, -> { where(support_module: nil).where(is_completed: true) }
+  scope :without_choice, -> { where(support_module: nil).where(is_completed: false) }
 
   def available_support_modules
     SupportModule.where(id: available_support_module_list)
-  end
-
-  def name
-    return support_module.name if support_module
-    return "Laisse le choix à 1001mots" if is_completed
-
-    "Pas encore choisi"
   end
 
   def support_module_collection

--- a/app/models/children_support_module.rb
+++ b/app/models/children_support_module.rb
@@ -35,11 +35,26 @@ class ChildrenSupportModule < ApplicationRecord
   scope :with_the_choice_to_make_by_us, -> { where(support_module: nil).where(is_completed: true) }
   scope :without_choice, -> { where(support_module: nil).where(is_completed: false) }
 
+  validate :support_module_not_programmed, on: :create
+  validate :valid_child_parent
+
   def available_support_modules
     SupportModule.where(id: available_support_module_list)
   end
 
   def support_module_collection
     SupportModule.where(id: available_support_module_list).map(&:decorate)
+  end
+
+  def support_module_not_programmed
+    if ChildrenSupportModule.exists?(child: child, parent: parent, is_programmed: false)
+      errors.add(:base, :invalid, message: "Un module choisi par le parent pour cet enfant n'a pas encore été programmé")
+    end
+  end
+
+  def valid_child_parent
+    unless parent.children.to_a.include? child
+      errors.add(:base, :invalid, message: "Cet enfant n'appartient pas à ce parent")
+    end
   end
 end

--- a/app/services/child_support/select_module_service.rb
+++ b/app/services/child_support/select_module_service.rb
@@ -25,12 +25,13 @@ class ChildSupport::SelectModuleService
 
   def send_select_module_message(parent, available_support_module_list)
     return if available_support_module_list.reject(&:blank?).empty?
+    return if ChildrenSupportModule.exists?(child_id: @child.id, parent_id: parent.id, is_programmed: false)
 
     @child_support_module = ChildrenSupportModule.create!(child_id: @child.id, parent_id: parent.id, available_support_module_list: available_support_module_list)
 
-    selection_link = Rails.application.routes.url_helpers.edit_children_support_module_url(
+    selection_link = Rails.application.routes.url_helpers.children_support_module_link_url(
       @child_support_module.id,
-      :security_code => parent.security_code
+      :sc => parent.security_code
     )
 
     message = "1001mots : C'est le moment de choisir votre thème pour #{@child.first_name}. Cliquez ici pour recevoir le prochain livre et les messages #{selection_link}"

--- a/app/views/children_support_modules/edit.html.erb
+++ b/app/views/children_support_modules/edit.html.erb
@@ -4,6 +4,12 @@
 
     <%= simple_form_for @children_support_module, url: @action_path do |f| %>
 
+    <div class="row justify-content-sm-center accepted-fields">
+      <div class="col-sm-8">
+        <%= f.error_notification message: "Une erreur est survenue, veuillez transmettre votre choix à votre appelante, nous sommes désolé pour la gêne occasionnée." %>
+      </div>
+    </div>
+
     <h1>Sur quel thème voulez-vous recevoir des conseils (et un livre) ?</h1>
       <div style="display: flex; flex-flow: row wrap; justify-content: center; align-items: stretch; align-content: stretch; gap: 2rem ">
         <% @support_modules.decorate.each do |support_module| %>

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -53,6 +53,8 @@ fr:
       months_between_12_and_24: 1-2 ans
       months_more_than_24: 2+ ans
       not_ended: En cours
+      not_programmed: Pas encore programmé
+      programmed: Programmé
       single_message: Messages uniques
       todo: À faire
       call_2_4: Accompagnement renforcé
@@ -65,3 +67,6 @@ fr:
       without_parent_to_contact: Sans parent à contacter
       without_support: Non suivis
       without_supporter: Sans responsable
+      with_support_module: Module déjà choisi
+      with_the_choice_to_make_by_us: Laisse le choix à 1001mots
+      without_choice: Pas encore choisi

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -162,7 +162,8 @@ fr:
         child_last_name: Nom de famille
         child_first_name: Prénom de l'enfant
         parent_first_name: Prénom du parent
-        is_completed: Choisi par le parent?
+        is_completed: Choisi par le parent ?
+        is_programmed: Programmé ?
         child: Enfant
         parent: Parent
         support_module: Module

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
     get "updated", on: :collection
   end
 
+  get "s/:id", to: 'children_support_modules#edit', as: :children_support_module_link
+
   root to: redirect("/admin")
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -242,7 +242,7 @@ ActiveRecord::Schema.define(version: 2022_12_28_175332) do
     t.bigint "workshop_id"
     t.string "parent_response"
     t.bigint "quit_group_child_id"
-    t.boolean "parent_presence", default: false
+    t.string "parent_presence"
     t.date "acceptation_date"
     t.index ["discarded_at"], name: "index_events_on_discarded_at"
     t.index ["quit_group_child_id"], name: "index_events_on_quit_group_child_id"


### PR DESCRIPTION
- Le téléchargement du CSV des fiches de suivies s'arrête après ~400 lignes (au lieu de ~6000)
- Utiliser des URL courtes au lieu d'envoyer le lien de selection de module en entier dans le sms
- N'avoir qu'un seul choix possible par parent pour un enfant en non programmé
- Ajouter filtres et liens sur la page des Modules choisis par les parents
