### PR TITLE
Fix/workshop

### DIFF
--- a/app/assets/stylesheets/admin/events.sass
+++ b/app/assets/stylesheets/admin/events.sass
@@ -44,7 +44,7 @@ $timeline-color: #5E6469
       font-size: 12px
 
     &.text-message, &.workshop-participation, &.other-event, &.survey-response
-      .body, .comments
+      .body
         margin-top: 10px
         border: 1px solid #dedede
         background-color: #f1f1f1
@@ -55,3 +55,7 @@ $timeline-color: #5E6469
         white-space: pre-wrap
         height: 3rem
         overflow: hidden
+      .workshop-participation-comment
+        font-weight: bold
+        background-color: #7c7c7c
+        color: #f1f1f1

--- a/app/decorators/events/workshop_participation_decorator.rb
+++ b/app/decorators/events/workshop_participation_decorator.rb
@@ -18,7 +18,7 @@ class Events::WorkshopParticipationDecorator < EventDecorator
         when "not_planned_absence"
           "a été absent à l'atelier (absence non prévue)"
         when "queue"
-          "est sur la file d'attente de l'atelier"
+          "est sur la liste d'attente pour cet atelier"
         else
           "a accepté l'invitation à un atelier le #{acceptation_date}"
         end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -53,7 +53,7 @@ class Workshop < ApplicationRecord
     self.name = "#{workshop_date.day}/#{workshop_date.month}/#{workshop_date.year}"
     self.name = location.nil? ? "Atelier du #{name}" : "Atelier du #{name} à #{location}"
     self.name = "#{name}, avec #{animator.name}"
-    self.name = "#{name}, sur le thème #{Workshop.human_attribute_name("topic.#{topic}")}" unless topic.blank?
+    self.name = "#{name}, sur le thème \"#{Workshop.human_attribute_name("topic.#{topic}")}\"" unless topic.blank?
   end
 
   def set_workshop_participation

--- a/app/views/admin/events/_history.html.erb
+++ b/app/views/admin/events/_history.html.erb
@@ -20,7 +20,7 @@
 
       <% elsif event.model.is_a?(Events::WorkshopParticipation) %>
 
-        <div class="comments"><%= event.comments %></div>
+        <div class="body workshop-participation-comment"><%= event.comments %></div>
 
       <% elsif event.model.is_a?(Events::OtherEvent) %>
 

--- a/app/views/admin/workshops/register_parents.erb
+++ b/app/views/admin/workshops/register_parents.erb
@@ -1,0 +1,33 @@
+<%= semantic_form_for(Workshop.new, url: @perform_action) do |f| %>
+
+  <%= f.inputs do %>
+
+    <%= f.hidden_field  :workshop_id,
+                        name: 'workshop_id',
+                        value: @workshop_id %>
+
+    <%= f.input :parents,
+                multiple: true,
+                label: "Parents",
+                collection: parent_select_collection,
+                input_html: {
+                  data: {
+                    select2: {
+                      tags: true,
+                      tokenSeparators: [","]
+                    }
+                  }
+                }
+    %>
+
+    <%= f.actions do %>
+      <%= f.action :submit, label: 'Valider' %>
+    <% end %>
+
+  <% end %>
+
+<% end %>
+
+<%= javascript_tag do %>
+  $('body').addClass('edit');
+<% end %>

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -400,8 +400,8 @@ fr:
         display_parent_presence: Presence du parent
       event/parents_presence:
         present: Présent
-        planned_absence: Absence prévue
-        not_planned_absence: Absence non prévue
+        planned_absence: Absence prévenue
+        not_planned_absence: Absence non prévenue
         queue: Sur liste d'attente
       field_comment:
         << : *SHARED


### PR DESCRIPTION
- Possibilité d’ajouter un parent manuellement dans la liste des inscrits
- Rendre rétroactif le changement de date d’un atelier : actuellement, si je modifie la date de mon atelier après l’envoi des invitations et la réponse des parents, l’événement dans l’historique reste à la date initiale (pas si urgent, car ne concerne qu’un cas particulier de temps en temps)
- Ajouter une case à cocher “atelier annulé”, qui mettrait automatiquement la présence des parents inscrit comme “atelier annulé”, avec comme titre de l’événement dans l’Historique “X était inscrit à l’atelier, mais celui-ci a été annulé”