### PR TITLE
fix : retours selection des modules

### DIFF
--- a/app/admin/children_support_module.rb
+++ b/app/admin/children_support_module.rb
@@ -94,7 +94,7 @@ ActiveAdmin.register ChildrenSupportModule do
 
   batch_action :select_module, form: -> {
     {
-      I18n.t("activerecord.models.children_support_module") => SupportModule.pluck(:name, :id)
+      I18n.t("activerecord.models.children_support_module") => SupportModule.order("LOWER(name)").decorate.map { |sm| [sm.name_with_tags, sm.id] }
     }
   } do |ids, inputs|
     batch_action_collection.where(id: ids, is_programmed: false).update_all(

--- a/app/helpers/program_messages_helper.rb
+++ b/app/helpers/program_messages_helper.rb
@@ -31,7 +31,7 @@ module ProgramMessagesHelper
       .map do |result|
       {
         id: result.id,
-        text: result.name
+        text: result.name_with_tags
       }
     end
   end


### PR DESCRIPTION
Pour la liste des 3 module disponibles à partir du suivi ça à l'air de bien fonctionner ! (image 1)
Après il faudrait l'ajouter au moment où on attribue un module par défaut (image 2). Et aussi dans l'onglet programmation de module (notamment si l'envoi du 1er module lecture se fait ici) pour différencier les modules (image 3).