### PR TITLE
fix: use correct timezone when using spothit

### DIFF
--- a/app/services/program_message_service.rb
+++ b/app/services/program_message_service.rb
@@ -3,7 +3,7 @@ class ProgramMessageService
   attr_reader :errors
 
   def initialize(planned_date, planned_hour, recipients, message, file = nil, redirection_target_id = nil, quit_message = false, workshop_id = nil)
-    @planned_timestamp = Time.zone.parse("#{planned_date} #{planned_hour}").to_i
+    @planned_timestamp = Time.parse("#{planned_date} #{planned_hour}").in_time_zone('Europe/Paris').to_i
     @recipients = recipients || []
     @message = message
     @file = file


### PR DESCRIPTION
https://trello.com/c/eeKJVdwy/132-bug-programmation-des-sms-dans-spot-hit-avec-la-mauvaise-timezone-on-pense-les-envoyer-%C3%A0-12h30-mais-ils-partent-%C3%A0-14h30