### PR TITLE
fix : children_support_module index not set properly

### DIFF
--- a/app/jobs/children_support_module/program_support_module_sms_job.rb
+++ b/app/jobs/children_support_module/program_support_module_sms_job.rb
@@ -39,7 +39,7 @@ class ChildrenSupportModule
       group.support_module_programmed += 1
       group.save(validate: false)
 
-      ChildrenSupportModule.where(child_id: current_children + not_current_children).update_all(module_index: group.support_module_programmed)
+      ChildrenSupportModule.not_programmed.where(child_id: not_current_children).update_all(module_index: group.support_module_programmed)
     end
   end
 end

--- a/app/services/child_support/program_chosen_modules_service.rb
+++ b/app/services/child_support/program_chosen_modules_service.rb
@@ -27,7 +27,13 @@ class ChildSupport::ProgramChosenModulesService
 
       raise service.errors.join("\n") if service.errors.any?
 
-      ChildrenSupportModule.where(id: children_support_modules.map(&:id)).update_all(is_programmed: true)
+      # support_module_programmed has not been incremented yet at this moment
+      # so we add +1 to the current count. It will be incremented after this service in ProgramSupportModuleSmsJob
+      # if there is no error
+      ChildrenSupportModule.where(id: children_support_modules.map(&:id)).update_all(
+        is_programmed: true,
+        module_index: group.support_module_programmed + 1
+      )
 
       # to avoid sending to many api calls to spot-hit, sleep 60 seconds between each module
       sleep(60)


### PR DESCRIPTION
**Actuellement** : on update les `module_index` des ChildrenSupportModule des enfants du Group APRES les avoir marqué comme programmé (dans ProgramSupportModuleSmsJob). On fait un update_all sur TOUS les ChildrenSupportModules des enfants du Group (= on override la valeur précédente)

**Le fix** : update des `module_index` des ChildrenSupportModule en train d’être programmés uniquement, pour ne pas toucher à ceux des modules passés.