### PR TITLE
fix(children support modules) : correctly increment module index

### DIFF
--- a/app/jobs/children_support_module/program_support_module_sms_job.rb
+++ b/app/jobs/children_support_module/program_support_module_sms_job.rb
@@ -35,11 +35,12 @@ class ChildrenSupportModule
 
       raise errors.to_json if errors.any?
 
+      ChildrenSupportModule.not_programmed.where(child_id: not_current_children).update_all(
+        module_index: group.support_module_programmed + 1
+      )
       ChildrenSupportModule.where(child_id: not_current_children).update_all(is_programmed: true)
       group.support_module_programmed += 1
       group.save(validate: false)
-
-      ChildrenSupportModule.not_programmed.where(child_id: not_current_children).update_all(module_index: group.support_module_programmed)
     end
   end
 end


### PR DESCRIPTION
La dernière ligne ne servait à rien vu qu'ils sont tous indiqués comme programmés à ce stade.
On update le module_index de ceux qui ne sont pas programmés (= ceux qui appartiennent aux modules qu'on programme actuellement) et seulement après on les indique tous comme programmés.