### PR TITLE
fix : check_all_child_supports_are_associated commented

### DIFF
--- a/app/services/group/distribute_child_supports_to_supporters_service.rb
+++ b/app/services/group/distribute_child_supports_to_supporters_service.rb
@@ -156,6 +156,14 @@ class Group
       return if child_supports_without_supporter_count.zero?
 
       Rollbar.error("#{child_supports_without_supporter_count} familles n'ont pas pu être associées à une appelante, l'opération est annulée, veuillez contacter le pôle technique.")
+      logistics_team_members.each do |ltm|
+        Task.create(
+          assignee_id: ltm.id,
+          title: "Toutes les fiches de suivi n'ont pas d'appelante",
+          description: "#{child_supports_without_supporter_count} familles n'ont pas pu être associées à une appelante, l'opération est annulée, veuillez contacter le pôle technique.",
+          due_date: Time.zone.today
+        )
+      end
     end
   end
 end

--- a/app/services/group/distribute_child_supports_to_supporters_service.rb
+++ b/app/services/group/distribute_child_supports_to_supporters_service.rb
@@ -160,7 +160,7 @@ class Group
         Task.create(
           assignee_id: ltm.id,
           title: "Toutes les fiches de suivi n'ont pas d'appelante",
-          description: "#{child_supports_without_supporter_count} familles n'ont pas pu être associées à une appelante, l'opération est annulée, veuillez contacter le pôle technique.",
+          description: "#{child_supports_without_supporter_count} familles n'ont pas pu être associées à une appelante. Filtrez les fiches de suivi de la cohorte sans appelante et procédez à une attribution manuelle depuis l'action groupée",
           due_date: Time.zone.today
         )
       end

--- a/app/services/group/distribute_child_supports_to_supporters_service.rb
+++ b/app/services/group/distribute_child_supports_to_supporters_service.rb
@@ -18,7 +18,7 @@ class Group
         balance_capacity_of_each_supporter
         child_supports_order_by_registration_source = order_child_supports
         associate_child_support_to_supporters(child_supports_order_by_registration_source)
-        # check_all_child_supports_are_associated
+        check_all_child_supports_are_associated
       end
     end
 
@@ -155,7 +155,7 @@ class Group
       child_supports_without_supporter_count = @group.child_supports.joins(:children).where(supporter_id: nil, children: { group_status: 'active' }).count
       return if child_supports_without_supporter_count.zero?
 
-      raise "#{child_supports_without_supporter_count} familles n'ont pas pu être associées à une appelante, l'opération est annulée, veuillez contacter le pôle technique."
+      Rollbar.error("#{child_supports_without_supporter_count} familles n'ont pas pu être associées à une appelante, l'opération est annulée, veuillez contacter le pôle technique.")
     end
   end
 end

--- a/app/services/group/distribute_child_supports_to_supporters_service.rb
+++ b/app/services/group/distribute_child_supports_to_supporters_service.rb
@@ -18,7 +18,7 @@ class Group
         balance_capacity_of_each_supporter
         child_supports_order_by_registration_source = order_child_supports
         associate_child_support_to_supporters(child_supports_order_by_registration_source)
-        check_all_child_supports_are_associated
+        # check_all_child_supports_are_associated
       end
     end
 


### PR DESCRIPTION
Permettre l'attribution des appelantes même s'il reste des enfants non attribués