### PR TITLE
Mise en prod du 28 Septembre

### DIFF
--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -43,7 +43,8 @@ ActiveAdmin.register ChildSupport do
   scope :without_supporter, group: :supporter
 
   scope :with_book_not_received
-  scope :call_2_4, group: :call
+  scope :call_2_4
+  scope :paused_or_stopped
 
   filter :availability, as: :string
   filter :call_infos, as: :string
@@ -52,11 +53,6 @@ ActiveAdmin.register ChildSupport do
          collection: proc { child_group_select_collection },
          input_html: { multiple: true, data: { select2: {} } },
          label: 'Cohorte'
-  filter :active_group_id_in,
-         as: :select,
-         collection: proc { child_group_select_collection },
-         input_html: { multiple: true, data: { select2: {} } },
-         label: 'Cohorte active'
   filter :without_parent_text_message_since,
          as: :datepicker,
          required: false,

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -100,7 +100,7 @@ ActiveAdmin.register Group do
       end
       tab I18n.t('group.scheduled_jobs') do
         panel I18n.t('group.panel_scheduled_jobs') do
-          render 'admin/groups/group_scheduled_jobs', scheduled_jobs: Group::GetScheduledJobsService.new(resource.id).call.scheduled_jobs
+          render 'admin/groups/group_scheduled_jobs', scheduled_jobs_group_by_module_number: Group::GetScheduledJobsService.new(resource.id).call.scheduled_jobs.group_by { |job| job[:module_number] }
         end
       end
     end

--- a/app/services/group/get_scheduled_jobs_service.rb
+++ b/app/services/group/get_scheduled_jobs_service.rb
@@ -9,7 +9,7 @@ class Group
       'ChildrenSupportModule::ProgramFirstSupportModuleJob' => 'Programmation du 1er module',
       'ChildrenSupportModule::FillParentsAvailableSupportModulesJob' => 'Ajout des modules disponibles sur les fiches de suivi',
       'ChildrenSupportModule::VerifyAvailableModulesTaskJob' => 'Vérification que tous les enfants ont des modules disponibles sur leur fiche de suivi',
-      'ChildrenSupportModule::CreateChildrenSupportModuleJob' => 'Préparation préalable au choix des parents',
+      'ChildrenSupportModule::CreateChildrenSupportModuleJob' => 'Préparation préalable au choix des parents pour l’appel 2',
       'ChildrenSupportModule::SelectDefaultSupportModuleJob' => 'Assignation des modules par défaut',
       'ChildrenSupportModule::VerifyChosenModulesTaskJob' => 'Détection des modules sans choix',
       'ChildrenSupportModule::CheckCreditsForGroupJob' => 'Vérification du nombre suffisant de crédits pour la programmation des modules',
@@ -19,6 +19,7 @@ class Group
 
     def initialize(group_id)
       @group_id = group_id
+      @module_number = Group.find(group_id).support_modules_count
       @scheduled_jobs = []
     end
 
@@ -30,6 +31,7 @@ class Group
         add_scheduled_job(job)
       end
       @scheduled_jobs.sort_by! { |hash| hash[:scheduled_date] }
+      set_module_numbers
 
       self
     end
@@ -39,7 +41,6 @@ class Group
     def add_scheduled_job(job)
       job_class_name = job.args[0]['job_class']
       job_group_id = job.args[0]['arguments']&.first
-      job_scheduled_date = job.at
       return unless GROUP_JOB_CLASS_NAMES.key?(job_class_name) && job_group_id == @group_id.to_i
 
       name = if job_class_name == ChildrenSupportModule::SelectModuleJob.to_s && job.args[0]['arguments']&.third.eql?(true)
@@ -47,7 +48,21 @@ class Group
              else
                GROUP_JOB_CLASS_NAMES[job_class_name]
              end
+
+      update_scheduled_jobs(job, name)
+    end
+
+    def update_scheduled_jobs(job, name)
+      job_scheduled_date = job.at
       @scheduled_jobs << { name: name, scheduled_date: job_scheduled_date }
+    end
+
+    def set_module_numbers
+      @scheduled_jobs.reverse.each do |scheduled_job|
+        scheduled_job[:module_number] = @module_number
+        @module_number -= 1 if scheduled_job[:name] == GROUP_JOB_CLASS_NAMES['ChildrenSupportModule::FillParentsAvailableSupportModulesJob']
+        scheduled_job[:module_number] = 1 if scheduled_job[:name] == GROUP_JOB_CLASS_NAMES['ChildrenSupportModule::ProgramFirstSupportModuleJob']
+      end
     end
   end
 end

--- a/app/services/group/program_service.rb
+++ b/app/services/group/program_service.rb
@@ -17,10 +17,10 @@ class Group
         verify_available_module_list
         create_call2_children_support_module
         program_sms_to_choose_module2_to_parents
+        program_sms_to_choose_module_to_parents
         select_default_support_module
         verify_chosen_modules
         program_check_spothit_credits
-        program_sms_to_choose_module_to_parents
         program_support_module_sms
         @group.update(is_programmed: true)
       end

--- a/app/views/admin/groups/_group_scheduled_jobs.html.erb
+++ b/app/views/admin/groups/_group_scheduled_jobs.html.erb
@@ -1,7 +1,14 @@
-<% scheduled_jobs.each do |job| %>
+<% scheduled_jobs_group_by_module_number.each do |(module_number, jobs)| %>
   <div>
-    <strong><%= job[:scheduled_date].strftime('%d/%m/%Y - %H:%M') %></strong>
+    <h3>Module <%= module_number %></h3>
+    <div>
+      <% jobs.each do |job| %>
+        <div>
+          <strong><%= job[:scheduled_date].strftime('%d/%m/%Y - %H:%M') %></strong>
+          <%= job[:name] %>
+        </div>
+      <% end %>
+    </div>
+    <hr class="dashed">
   </div>
-  <div><%= job[:name] %></div>
-  <hr class="dashed">
 <% end %>

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -59,6 +59,8 @@ fr:
       single_message: Messages uniques
       todo: À faire
       call_2_4: Accompagnement renforcé
+      with_a_child_in_active_group: Cohorte active
+      paused_or_stopped: Cohorte en pause ou arrêtée
       only_siblings: Seulement les fratries
       waiting_second_group: Attente de 2eme cohorte
       with_book_not_received: Ayant un livre non reçu


### PR DESCRIPTION
#### Affichage par défaut des suivis "actifs" dans l'index des suivi
Dans l’index des suivis, voir rapidement les familles à appeler. Ne pas afficher les familles inactives par défaut pour éviter de les appeler par erreur.
- Dans l’index des suivis, il faut que le scope “Sous ma responsabilité” et “Accompagnement renforcé” renvoient uniquement les familles qui ont au moins un enfant en cohorte active.
- Ajouter un scope “Cohorte en pause ou arrêtée” dans lequel n’apparaitront que les familles où tous les enfants ont la cohorte en pause ou arrêtée.
#### Affichage des jobs programmés regroupés par numéro de module (En staging)
