### PR TITLE
Children Support Modules : Choisi par les parents coché par défaut

### DIFF
--- a/app/admin/children_support_module.rb
+++ b/app/admin/children_support_module.rb
@@ -37,7 +37,7 @@ ActiveAdmin.register ChildrenSupportModule do
   form do |f|
     f.semantic_errors *f.object.errors.keys
     if params[:action] == "new"
-      f.object.is_completed = params[:is_completed] if params[:is_completed]
+      f.object.is_completed = true
       f.object.parent_id = params[:parent_id] if params[:parent_id]
       f.object.child_id = params[:child_id] if params[:child_id]
       f.object.available_support_module_list = params[:available_support_module_list] if params[:available_support_module_list]

--- a/app/models/children_support_module.rb
+++ b/app/models/children_support_module.rb
@@ -56,6 +56,8 @@ class ChildrenSupportModule < ApplicationRecord
   end
 
   def available_support_modules
+    return [] if available_support_module_list.blank?
+
     SupportModule.find(available_support_module_list.reject(&:blank?))
   end
 


### PR DESCRIPTION
+ correction d'une erreur lorsqu'on accède à la page de création d'un ChildrenSupportModule sans module disponible