### PR TITLE
ChildrenSupportModules : module_index assignment at creation

### DIFF
--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -168,12 +168,11 @@ ActiveAdmin.register Group do
   action_item :children_support_modules_informations, only: :show do
     if resource.model.support_module_programmed.positive?
       dropdown_menu 'Récupérer les informations des modules choisis' do
-        (0..resource.model.support_module_programmed - 1).each do |index|
+        (0..resource.model.support_modules_count).each do |index|
           next if index.zero? && resource.model.started_at < DateTime.parse(ENV['MODULE_ZERO_FEATURE_START'])
 
-          item "Module #{index}", children_support_modules_informations_admin_group_path(index: index + 1)
+          item "Module #{index} #{'(Pas encore programmé)' if index >= resource.model.support_module_programmed}", children_support_modules_informations_admin_group_path(index: index + 1)
         end
-        item 'Module en préparation', children_support_modules_informations_admin_group_path(index: 0)
       end
     end
   end

--- a/app/admin/group.rb
+++ b/app/admin/group.rb
@@ -167,11 +167,16 @@ ActiveAdmin.register Group do
 
   action_item :children_support_modules_informations, only: :show do
     if resource.model.support_module_programmed.positive?
+      group_without_module_zero = resource.model.started_at < DateTime.parse(ENV['MODULE_ZERO_FEATURE_START'])
       dropdown_menu 'Récupérer les informations des modules choisis' do
         (0..resource.model.support_modules_count).each do |index|
-          next if index.zero? && resource.model.started_at < DateTime.parse(ENV['MODULE_ZERO_FEATURE_START'])
+          next if index.zero? && group_without_module_zero
 
-          item "Module #{index} #{'(Pas encore programmé)' if index >= resource.model.support_module_programmed}", children_support_modules_informations_admin_group_path(index: index + 1)
+          ajusted_index = group_without_module_zero ? index - 1 : index
+          current_module = ajusted_index == resource.model.support_module_programmed
+          not_programmed = ajusted_index >= resource.model.support_module_programmed
+          item_text = "Module #{index} #{'- en cours de programmation' if current_module}#{'- à venir' if not_programmed && !current_module}"
+          item item_text, children_support_modules_informations_admin_group_path(index: group_without_module_zero ? index : index + 1)
         end
       end
     end

--- a/app/jobs/children_support_module/create_children_support_module_job.rb
+++ b/app/jobs/children_support_module/create_children_support_module_job.rb
@@ -5,6 +5,7 @@ class ChildrenSupportModule
     def perform(group_id)
       errors = {}
       group = Group.find(group_id)
+      next_module_index = group.support_module_programmed + 1
 
       group.children.includes(:parent1, :parent2, :child_support).where(group_status: 'active').find_each do |child|
         unless child.child_support
@@ -14,11 +15,13 @@ class ChildrenSupportModule
 
         parent1_children_support_module = ChildrenSupportModule.create(child_id: child.id,
                                                                        parent_id: child.parent1.id,
-                                                                       available_support_module_list: child.child_support&.parent1_available_support_module_list)
+                                                                       available_support_module_list: child.child_support&.parent1_available_support_module_list,
+                                                                       module_index: next_module_index)
         if child.parent2
           parent2_children_support_module = ChildrenSupportModule.create(child_id: child.id,
                                                                          parent_id: child.parent2.id,
-                                                                         available_support_module_list: child.child_support&.parent2_available_support_module_list)
+                                                                         available_support_module_list: child.child_support&.parent2_available_support_module_list,
+                                                                         module_index: next_module_index)
         end
 
         errors[child.id] = handle_errors([parent1_children_support_module, parent2_children_support_module]) if parent1_children_support_module&.errors&.any? || parent2_children_support_module&.errors&.any?

--- a/app/jobs/children_support_module/program_support_module_sms_job.rb
+++ b/app/jobs/children_support_module/program_support_module_sms_job.rb
@@ -55,9 +55,6 @@ class ChildrenSupportModule
     end
 
     def update_children_support_module(children)
-      ChildrenSupportModule.not_programmed.where(child_id: children).update(
-        module_index: group.support_module_programmed + 1
-      )
       ChildrenSupportModule.where(child_id: children).update(is_programmed: true)
     end
 

--- a/app/jobs/children_support_module/select_module_job.rb
+++ b/app/jobs/children_support_module/select_module_job.rb
@@ -2,10 +2,12 @@ class ChildrenSupportModule
 
   class SelectModuleJob < ApplicationJob
 
-    def perform(group_id, select_module_date, second_support_module = false)
+    def perform(group_id, select_module_date, module_index)
       errors = {}
       group = Group.find(group_id)
-      children = if second_support_module
+      # module_index starts with 1
+      # so if module_index == 3 it means this is Module 2 (that comes after Module 0 and 1)
+      children = if module_index.eql?(3)
                    group.children.where(group_status: 'active').joins(:child_support).where(child_supports: { call2_status: ['KO', 'Ne pas appeler'] })
                  else
                    group.children.where(group_status: 'active')
@@ -27,7 +29,7 @@ class ChildrenSupportModule
           child,
           select_module_date.sunday? ? select_module_date.next_day : select_module_date,
           '12:30',
-          second_support_module
+          module_index
         ).call
         errors[child.id] = service.errors if service.errors.any?
       end

--- a/app/models/children_support_module.rb
+++ b/app/models/children_support_module.rb
@@ -48,6 +48,7 @@ class ChildrenSupportModule < ApplicationRecord
 
   after_update :select_for_the_other_parent
   after_update :select_for_siblings
+  before_create :set_module_index
 
   def name
     return support_module.decorate.name_with_tags if support_module
@@ -162,5 +163,12 @@ class ChildrenSupportModule < ApplicationRecord
       choice_date: choice_date,
       is_completed: is_completed
     )
+  end
+
+  def set_module_index
+    return unless child&.group.present? && self.module_index.blank?
+
+    next_module_index = child.group.support_module_programmed + 1
+    self.module_index = next_module_index
   end
 end

--- a/app/services/child_support/program_chosen_modules_service.rb
+++ b/app/services/child_support/program_chosen_modules_service.rb
@@ -27,13 +27,7 @@ class ChildSupport::ProgramChosenModulesService
 
       raise service.errors.join("\n") if service.errors.any?
 
-      # support_module_programmed has not been incremented yet at this moment
-      # so we add +1 to the current count. It will be incremented after this service in ProgramSupportModuleSmsJob
-      # if there is no error
-      ChildrenSupportModule.where(id: children_support_modules.map(&:id)).update_all(
-        is_programmed: true,
-        module_index: group.support_module_programmed + 1
-      )
+      ChildrenSupportModule.where(id: children_support_modules.map(&:id)).update_all(is_programmed: true)
 
       # to avoid sending to many api calls to spot-hit, sleep 60 seconds between each module
       sleep(60)

--- a/app/services/child_support/select_module_service.rb
+++ b/app/services/child_support/select_module_service.rb
@@ -2,11 +2,11 @@ class ChildSupport::SelectModuleService
 
   attr_reader :errors
 
-  def initialize(child, planned_date, planned_hour, second_support_module = false)
+  def initialize(child, planned_date, planned_hour, module_index)
     @child = child
     @planned_date = planned_date
     @planned_hour = planned_hour
-    @second_support_module = second_support_module
+    @module_index = module_index
     @errors = []
   end
 
@@ -28,7 +28,7 @@ class ChildSupport::SelectModuleService
     return if available_support_module_list.reject(&:blank?).empty?
 
     @children_support_module = ChildrenSupportModule.find_by(child_id: @child.id, parent_id: parent.id, is_programmed: false)
-    @children_support_module ||= ChildrenSupportModule.create!(child_id: @child.id, parent_id: parent.id, available_support_module_list: available_support_module_list)
+    @children_support_module ||= ChildrenSupportModule.create!(child_id: @child.id, parent_id: parent.id, available_support_module_list: available_support_module_list, module_index: @module_index)
 
     if @children_support_module.available_support_module_list.reject(&:blank?).size == 1
       chose_support_module
@@ -43,7 +43,9 @@ class ChildSupport::SelectModuleService
       sc: parent.security_code
     )
 
-    date = @second_support_module ? 'deux jours' : 'quelques jours'
+    # module_index starts with 1
+    # so if module_index == 3 it means this is "Module 2" (that comes after "Module 0" and "Module 1")
+    date = @module_index.eql?(3) ? 'deux jours' : 'quelques jours'
 
     message = "1001mots : Cliquez sur le lien pour choisir votre prochain thème pour #{@child.first_name} et recevoir un nouveau livre. Attention dans #{date}, nous choisirons à votre place ! #{selection_link}"
 

--- a/app/services/children_support_module/program_service.rb
+++ b/app/services/children_support_module/program_service.rb
@@ -6,6 +6,7 @@ class ChildrenSupportModule
       @errors = {}
       group = Group.find(group_id)
       module_number = group.support_module_programmed
+      @module_index = group.support_module_programmed.to_i + 1
       create_group_children_support_module(group, age_ranges, theme)
       ChildrenSupportModule::ProgramSupportModuleSmsJob.perform_later(group_id, program_date)
       return unless @errors.any?
@@ -47,7 +48,8 @@ class ChildrenSupportModule
         child_id: child.id,
         parent_id: parent.id,
         available_support_module_list: [support_module.id],
-        support_module: support_module
+        support_module: support_module,
+        module_index: @module_index
       )
       @errors["child: #{child.id} - parent: #{parent.id}"] = parent_children_support_module.errors if parent_children_support_module.errors.any?
     end

--- a/app/services/group/children_support_modules_informations_service.rb
+++ b/app/services/group/children_support_modules_informations_service.rb
@@ -16,17 +16,9 @@ class Group
     end
 
     def call
-      if @index.to_i.zero?
-        last_csm_programmed_date = ChildrenSupportModule.joins(child: :group).where(groups: { id: @group.id }).where(children_support_modules: { is_programmed: true }).maximum(:created_at)
-        child_and_parent1_ids.each do |child_id, parent1_id|
-          csm = ChildrenSupportModule.with_support_module.find_by('child_id = ? AND parent_id = ? AND children_support_modules.created_at >= ? AND is_programmed = ? AND module_index IS NULL', child_id, parent1_id, last_csm_programmed_date.to_date, false)
-          @support_modules_count[csm.support_module.name.to_sym] += 1 if csm
-        end
-      else
-        child_and_parent1_ids.each do |child_id, parent1_id|
-          csm = ChildrenSupportModule.with_support_module.find_by(child_id: child_id, parent_id: parent1_id, module_index: @index)
-          @support_modules_count[csm.support_module.name.to_sym] += 1 if csm
-        end
+      child_and_parent1_ids.each do |child_id, parent1_id|
+        csm = ChildrenSupportModule.with_support_module.find_by(child_id: child_id, parent_id: parent1_id, module_index: @index)
+        @support_modules_count[csm.support_module.name.to_sym] += 1 if csm
       end
 
       init_excel_file

--- a/app/services/group/program_service.rb
+++ b/app/services/group/program_service.rb
@@ -81,8 +81,9 @@ class Group
     end
 
     def program_sms_to_choose_module2_to_parents
+      # "Module 2" ==> module_index 3
       select_module_date = @group.started_at + 6.weeks - 3.days + MODULE_ZERO_DURATION
-      ChildrenSupportModule::SelectModuleJob.set(wait_until: select_module_date.to_datetime.change(hour: 6)).perform_later(@group.id, select_module_date, true)
+      ChildrenSupportModule::SelectModuleJob.set(wait_until: select_module_date.to_datetime.change(hour: 6)).perform_later(@group.id, select_module_date, 3)
     end
 
     def select_default_support_module
@@ -111,7 +112,7 @@ class Group
 
       (4..@group.support_modules_count).each do |module_index|
         select_module_date = (@group.started_at + ((module_index - 2) * 8.weeks) - 4.weeks + MODULE_ZERO_DURATION).next_occurring(:saturday)
-        ChildrenSupportModule::SelectModuleJob.set(wait_until: select_module_date.to_datetime.change(hour: 6)).perform_later(@group.id, select_module_date)
+        ChildrenSupportModule::SelectModuleJob.set(wait_until: select_module_date.to_datetime.change(hour: 6)).perform_later(@group.id, select_module_date, module_index)
       end
     end
 

--- a/spec/services/child_support/select_module_service_spec.rb
+++ b/spec/services/child_support/select_module_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ChildSupport::SelectModuleService do
   let(:planned_date) { Time.zone.today }
   let(:planned_hour) { Time.zone.now.strftime('%H:%M') }
 
-  subject { ChildSupport::SelectModuleService.new(child, planned_date, planned_hour).call }
+  subject { ChildSupport::SelectModuleService.new(child, planned_date, planned_hour, 1).call }
 
   context 'when no parent should be contacted' do
     it 'gets an error message' do


### PR DESCRIPTION
https://trello.com/c/Ug2gkM2T/202-renseigner-lindex-dun-choix-de-module-d%C3%A8s-sa-cr%C3%A9ation-sans-attendre-sa-programmation

/!\ Lors de la mise en prod / staging : il faut supprimer les Jobs `ChildrenSupportModule::SelectModuleJob` pour passer le `module_index` en dernier param