### PR TITLE
feat(children) : change group action to swap children to another grou…

### DIFF
--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -138,11 +138,11 @@ ActiveAdmin.register Child do
 
   batch_action :add_to_group, form: -> {
     {
-      I18n.t('activerecord.models.group') => Group.not_ended.order(:name).pluck(:name, :id)
+      I18n.t('activerecord.models.group') => Group.not_started.order(:name).pluck(:name, :id)
     }
   } do |ids, inputs|
-    if batch_action_collection.where(id: ids).with_group.any?
-      flash[:error] = 'Certains enfants sont déjà dans une cohorte'
+    if batch_action_collection.where(id: ids).with_ongoing_group.any?
+      flash[:error] = 'Certains enfants sont dans une cohorte déjà lancée'
       redirect_to request.referer
     else
       group = Group.find(inputs[I18n.t('activerecord.models.group')])

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -161,6 +161,7 @@ class Child < ApplicationRecord
   scope :available_for_the_workshops, -> { where(available_for_workshops: true) }
   scope :active_group, -> { where(group_status: 'active') }
   scope :only_siblings, -> { where(child_support_id: ChildSupport.multiple_children.select(:id)) }
+  scope :with_ongoing_group, -> { joins(:group).merge(Group.started) }
 
   def self.without_group_and_not_waiting_second_group
     second_group_children_ids = Child.tagged_with('2eme cohorte').pluck(:id)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -52,6 +52,8 @@ class Group < ApplicationRecord
 
   scope :not_ended, -> { where('ended_at IS NULL OR ended_at > ?', Date.today) }
   scope :ended, -> { where('ended_at <= ?', Date.today) }
+  scope :not_started, -> { where('started_at >= ? AND support_module_programmed = ?', Date.today, 0) }
+  scope :started, -> { where('started_at < ? OR support_module_programmed > ?', Date.today, 0) }
 
   # ---------------------------------------------------------------------------
   # helpers


### PR DESCRIPTION
Modif du comportement du bouton "Ajouter à une cohorte les éléments..." : 
On peut déplacer des enfants d'un groupe à un autre tant que les groupes n'ont pas encore débuté (date de début pas dépassée et pas de module programmé)
https://trello.com/c/YpImx9yN/213-enfants-permettre-laction-de-groupe-ajouter-à-une-cohorte-si-les-cohortes-nont-pas-commencé