### PR TITLE
SMS fin d'accompagnement : envoyer le bon prénom des enfants concernés

### DIFF
--- a/app/services/child/stop_support_message_service.rb
+++ b/app/services/child/stop_support_message_service.rb
@@ -1,0 +1,30 @@
+class Child::StopSupportMessageService < ProgramMessageService
+  def format_data_for_spot_hit
+    @recipient_data = {}
+    @child_ids.each do |child_id|
+      child = Child.find(child_id)
+      fill_child_name_recipient_data(child.first_name, child.parent1_id.to_s)
+      fill_redirection_url_recipient_data(child, child.parent1)
+      next unless child.parent2
+
+      fill_child_name_recipient_data(child.first_name, child.parent2_id.to_s)
+      fill_redirection_url_recipient_data(child, child.parent2)
+    end
+  end
+
+  def fill_child_name_recipient_data(first_name, parent_id)
+    @recipient_data[parent_id] ||= {}
+    if @recipient_data[parent_id]['PRENOM_ENFANT'].present?
+      @recipient_data[parent_id]['PRENOM_ENFANT'] += " et #{first_name}"
+    else
+      @recipient_data[parent_id]['PRENOM_ENFANT'] = first_name
+    end
+  end
+
+  def fill_redirection_url_recipient_data(child, parent)
+    if @redirection_target
+      @recipient_data[parent.id.to_s]['URL'] = redirection_url_for_a_parent(parent, child.id)&.decorate&.visit_url
+      @url = RedirectionUrl.where(redirection_target: @redirection_target, parent: parent, child: child).first
+    end
+  end
+end

--- a/app/services/group/stop_support_service.rb
+++ b/app/services/group/stop_support_service.rb
@@ -39,7 +39,7 @@ class Group
     def sms_count(message, children_count)
       sms_to_send_count = 0
       sms_to_send_count += (message.gsub('{URL}', 'https://app.1001mots.org/r/xxxxxx/xx').size / 160) + 1
-      sms_to_send_count *= children_count
+      sms_to_send_count *= @children.parents.count # account for potential parent 2
       sms_to_send_count
     end
 
@@ -63,7 +63,7 @@ class Group
     end
 
     def program_message(children, message, date: Time.zone.today, link_id: @link_id, hour: '12:30')
-      service = ProgramMessageService.new(date, hour, children.map { |child| "child.#{child.id}" }, message, nil, link_id).call
+      service = Child::StopSupportMessageService.new(date, hour, children.map { |child| "child.#{child.id}" }, message, nil, link_id).call
       @errors += service.errors if service.errors.any?
     end
   end

--- a/app/services/program_message_service.rb
+++ b/app/services/program_message_service.rb
@@ -112,14 +112,15 @@ class ProgramMessageService
     end
   end
 
-  def redirection_url_for_a_parent(parent)
-    redirection_url = parent.redirection_urls.find_by(child_id: parent.current_child.id, parent_id: parent.id, redirection_target_id: @redirection_target.id)
+  def redirection_url_for_a_parent(parent, child_id = nil)
+    targeted_child_id = child_id || parent.current_child.id
+    redirection_url = parent.redirection_urls.find_by(child_id: targeted_child_id, parent_id: parent.id, redirection_target_id: @redirection_target.id)
 
     if redirection_url.nil?
       redirection_url = RedirectionUrl.new(
         redirection_target_id: @redirection_target.id,
         parent_id: parent.id,
-        child_id: parent.current_child.id
+        child_id: targeted_child_id
       )
       @errors << "Problème(s) avec l'url courte." unless redirection_url.save
     end


### PR DESCRIPTION
https://trello.com/c/ad7XTQHU/220-afficher-le-nom-des-enfants-concern%C3%A9s-dans-les-sms-de-fin-daccompagnement