### PR TITLE
Child Supports : enregistrer les réponses du questionnaire Mi parcours

### DIFF
--- a/app/models/child_support.rb
+++ b/app/models/child_support.rb
@@ -116,6 +116,8 @@
 #  other_phone_number                    :string
 #  parent1_available_support_module_list :string           is an Array
 #  parent2_available_support_module_list :string           is an Array
+#  parent_mid_term_rate                  :integer
+#  parent_mid_term_reaction              :string
 #  second_language                       :string
 #  should_be_read                        :boolean
 #  to_call                               :boolean

--- a/app/services/typeform/midway_form_service.rb
+++ b/app/services/typeform/midway_form_service.rb
@@ -9,6 +9,7 @@ module Typeform
     def initialize(form_responses)
       @answers = form_responses[:answers]
       @parent = Parent.find(form_responses[:hidden][:parent_id])
+      @child_support = ChildSupport.find(form_responses[:hidden][:child_support_id])
     end
 
     def call
@@ -23,8 +24,18 @@ module Typeform
         end
       end
 
-      @parent.save(validate: false)
+      if @parent.save(validate: false)
+        @child_support.parent_mid_term_rate = @parent.reload.mid_term_rate if should_update_mid_term_info?(:parent_mid_term_rate)
+        @child_support.parent_mid_term_reaction = @parent.reload.mid_term_reaction if should_update_mid_term_info?(:parent_mid_term_reaction)
+        @child_support.save(validate: false)
+      end
       self
+    end
+
+    private
+
+    def should_update_mid_term_info?(mid_term_attribute)
+      (@parent == @child_support.parent1) || @child_support.send(mid_term_attribute).blank?
     end
   end
 end

--- a/db/migrate/20231218141318_add_mid_term_rate_and_mid_term_reaction_to_child_supports.rb
+++ b/db/migrate/20231218141318_add_mid_term_rate_and_mid_term_reaction_to_child_supports.rb
@@ -1,0 +1,6 @@
+class AddMidTermRateAndMidTermReactionToChildSupports < ActiveRecord::Migration[6.0]
+  def change
+    add_column :child_supports, :parent_mid_term_rate, :integer
+    add_column :child_supports, :parent_mid_term_reaction, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_14_104415) do
+ActiveRecord::Schema.define(version: 2023_12_18_141318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -249,6 +249,8 @@ ActiveRecord::Schema.define(version: 2023_11_14_104415) do
     t.text "call3_goals_sms"
     t.text "call4_goals_sms"
     t.text "call5_goals_sms"
+    t.integer "parent_mid_term_rate"
+    t.string "parent_mid_term_reaction"
     t.index ["book_not_received"], name: "index_child_supports_on_book_not_received"
     t.index ["call0_parent_progress"], name: "index_child_supports_on_call0_parent_progress"
     t.index ["call0_reading_frequency"], name: "index_child_supports_on_call0_reading_frequency"

--- a/spec/models/child_support_spec.rb
+++ b/spec/models/child_support_spec.rb
@@ -116,6 +116,8 @@
 #  other_phone_number                    :string
 #  parent1_available_support_module_list :string           is an Array
 #  parent2_available_support_module_list :string           is an Array
+#  parent_mid_term_rate                  :integer
+#  parent_mid_term_reaction              :string
 #  second_language                       :string
 #  should_be_read                        :boolean
 #  to_call                               :boolean


### PR DESCRIPTION
https://trello.com/c/zuqbZZYf/221-ajout-de-la-donn%C3%A9e-de-mi-parcours-dans-la-table-child-suport-avec-r%C3%A9troactivit%C3%A9-sur-la-cohorte-de-septembre
A lancer en prod pour générer le côté rétroactif Septembre : 
```ruby
ChildSupport.joins(:children).where(children: { group_id: 64, discarded_at: nil, group_status: 'active'}).distinct.find_each(batch_size: 250) do |child_support|
  parent1 = child_support.parent1
  parent2 = child_support.parent2
  next if parent1.mid_term_rate.blank? && parent2&.mid_term_rate.blank?

  parent_with_mid_term_answers = parent1.mid_term_rate.present? ? parent1 : parent2
  child_support.parent_mid_term_rate = parent_with_mid_term_answers.mid_term_rate
  child_support.parent_mid_term_reaction = parent_with_mid_term_answers.mid_term_reaction
  child_support.save(validate: false)
end
``` 