### PR TITLE
Fiche de suivi : filtre des statut d'appel avec valeur "Non renseigné"

### DIFF
--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -79,10 +79,7 @@ ActiveAdmin.register ChildSupport do
   filter :supporter,
          input_html: { data: { select2: {} } }
   (0..5).each do |call_idx|
-    filter "call#{call_idx}_status",
-           as: :select,
-           collection: proc { call_status_collection },
-           input_html: { data: { select2: {} } }
+    filter "call#{call_idx}_status_filter", as: :check_boxes,  label: "Statut de l'appel #{call_idx}", collection: proc { call_statuses_with_nil }
     filter "call#{call_idx}_duration"
     filter "call#{call_idx}_parent_progress_present",
            as: :boolean,

--- a/app/assets/stylesheets/admin/sidebar.sass
+++ b/app/assets/stylesheets/admin/sidebar.sass
@@ -7,3 +7,8 @@
         label
           input[type="checkbox"]
             height: 15px
+
+.filter_check_boxes
+  .choices label
+    display: block
+    margin-bottom: 5px

--- a/app/helpers/active_admin/child_supports_helper.rb
+++ b/app/helpers/active_admin/child_supports_helper.rb
@@ -93,4 +93,13 @@ module ActiveAdmin::ChildSupportsHelper
   def call_status_collection
     ChildSupport::CALL_STATUS.map { |v| ChildSupport.human_attribute_name("call_status.#{v}") }
   end
+
+  def call_statuses_with_nil
+    ChildSupport::CALL_STATUS.map do |v|
+      [
+        ChildSupport.human_attribute_name("call_status.#{v}"),
+        ChildSupport.human_attribute_name("call_status.#{v}")
+      ]
+    end.push(['Non renseigné', 'nil'])
+  end
 end


### PR DESCRIPTION
https://trello.com/c/s0Q25CiJ/209-index-suivi-pouvoir-filtrer-avec-option-vide-non-renseigné
On passe d'un select à des checkboxes
Utilisation de ransack pour passer outre les limitations d'active admin