### PR TITLE
Arrêt d'accompagnement des enfants de 36 mois au moment des SMS de choix de module

### DIFF
--- a/app/jobs/children_support_module/fill_parents_available_support_modules_job.rb
+++ b/app/jobs/children_support_module/fill_parents_available_support_modules_job.rb
@@ -3,7 +3,6 @@ class ChildrenSupportModule
   class FillParentsAvailableSupportModulesJob < ApplicationJob
 
     def perform(group_id, second_support_module)
-      Group::StopSupportService.new(group_id, end_of_support: false).call
       ChildSupport::FillParentsAvailableSupportModulesService.new(group_id, second_support_module).call
     end
   end

--- a/app/jobs/children_support_module/select_module_job.rb
+++ b/app/jobs/children_support_module/select_module_job.rb
@@ -5,6 +5,8 @@ class ChildrenSupportModule
     def perform(group_id, select_module_date, module_index)
       errors = {}
       group = Group.find(group_id)
+      # stop children of 36 months+ before sending next module choice SMS
+      Group::StopSupportService.new(group_id, end_of_support: false).call
       # module_index starts with 1
       # so if module_index == 3 it means this is Module 2 (that comes after Module 0 and 1)
       children = if module_index.eql?(3) && group.with_module_zero?

--- a/app/services/child_support/fill_parents_available_support_modules_service.rb
+++ b/app/services/child_support/fill_parents_available_support_modules_service.rb
@@ -79,10 +79,10 @@ class ChildSupport::FillParentsAvailableSupportModulesService
                         SupportModule::TWENTY_FOUR_TO_TWENTY_NINE
                       when 30..35
                         SupportModule::THIRTY_TO_THIRTY_FIVE
-                      when 36..40
-                        SupportModule::THIRTY_SIX_TO_FORTY
-                      when 41..44
-                        SupportModule::FORTY_ONE_TO_FORTY_FOUR
+                      # when 36..40
+                      #   SupportModule::THIRTY_SIX_TO_FORTY
+                      # when 41..44
+                      #   SupportModule::FORTY_ONE_TO_FORTY_FOUR
                       else
                         ''
                       end

--- a/app/services/child_support/verify_available_modules_task_service.rb
+++ b/app/services/child_support/verify_available_modules_task_service.rb
@@ -10,6 +10,8 @@ class ChildSupport::VerifyAvailableModulesTaskService
   def call
     @group.children.where(group_status: 'active').each do |child|
       @children_with_missing_child_support << child.id and next unless child.child_support
+      # this child will have its status set to "stopped" when SelectModuleJob runs, we can ignore
+      next if child.birthdate < 36.months.ago
 
       create_child_support_link(child)
     end

--- a/spec/jobs/children_support_module/fill_parents_available_support_modules_job_spec.rb
+++ b/spec/jobs/children_support_module/fill_parents_available_support_modules_job_spec.rb
@@ -53,9 +53,8 @@ RSpec.describe ChildrenSupportModule::FillParentsAvailableSupportModulesJob, typ
       FactoryBot.create(:support_module, level: 1, for_bilingual: false, theme: "songs", age_ranges: %w[twelve_to_seventeen], name: "Chanter avec mon bébé 🎶")
       FactoryBot.create(:support_module, level: 1, for_bilingual: false, theme: "songs", age_ranges: %w[five_to_eleven], name: "Chanter avec mon bébé 🎶")
 
-      allow_any_instance_of(Group::StopSupportService).to receive(:call).and_return(Group::StopSupportService.new(group.id))
 
-      (0...44).each do |month|
+      (0...35).each do |month|
         child = FactoryBot.create(:child, parent2_id: FactoryBot.create(:parent).id, group: group, group_status: 'active')
         # To avoid the validation of the birth_date
         child.birthdate = month.months.ago
@@ -82,7 +81,7 @@ RSpec.describe ChildrenSupportModule::FillParentsAvailableSupportModulesJob, typ
 
         group.children.each do |child|
           # parent1 ----
-          expect(child.child_support.parent1_available_support_module_list).not_to be_empty
+          expect(child.child_support.parent1_available_support_module_list).not_to be_blank
           # check the reading module is not in the list
           expect(
             child.child_support.parent1_available_support_module_list & child.children_support_modules.where(parent_id: child.parent1.id).pluck(:support_module_id)
@@ -95,7 +94,7 @@ RSpec.describe ChildrenSupportModule::FillParentsAvailableSupportModulesJob, typ
 
           # parent2 ----
           # check the reading module is not in the list
-          expect(child.child_support.parent2_available_support_module_list).not_to be_empty
+          expect(child.child_support.parent2_available_support_module_list).not_to be_blank
           expect(
             child.child_support.parent2_available_support_module_list & child.children_support_modules.where(parent_id: child.parent2.id).pluck(:support_module_id)
           ).to be_empty


### PR DESCRIPTION
Il faut envoyer le SMS de fin d'accompagnement au bon moment, et éviter de générer des faux positifs de la tâche de vérification des modules disponibles avec les enfants de 36 mois n'en ayant pas reçu