### PR TITLE
Ignorer certaines erreurs rollbar & fix d'une erreur potentielle lors d'envoi de msg

### DIFF
--- a/app/services/program_message_service.rb
+++ b/app/services/program_message_service.rb
@@ -158,9 +158,8 @@ class ProgramMessageService
   def find_parent_ids_from_groups
     Group.includes(:children).where(id: @group_ids).find_each do |group|
       group.children.each do |child|
-        next unless child.group_status == 'active' && child.child_support.present?
-
-        next if @supporter_id.present? && child.child_support.supporter_id != @supporter_id
+        next unless child.group_status == 'active'
+        next if @supporter_id.present? && child.child_support&.supporter_id != @supporter_id
 
         @parent_ids << child.parent1_id if child.parent1_id && child.should_contact_parent1
         @parent_ids << child.parent2_id if child.parent2_id && child.should_contact_parent2

--- a/app/services/program_message_service.rb
+++ b/app/services/program_message_service.rb
@@ -158,7 +158,7 @@ class ProgramMessageService
   def find_parent_ids_from_groups
     Group.includes(:children).where(id: @group_ids).find_each do |group|
       group.children.each do |child|
-        next unless child.group_status == 'active'
+        next unless child.group_status == 'active' && child.child_support.present?
 
         next if @supporter_id.present? && child.child_support.supporter_id != @supporter_id
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -30,7 +30,13 @@ if ENV['ROLLBAR_ACCESS_TOKEN']
     # via the rollbar interface.
     # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
     # 'ignore' will cause the exception to not be reported at all.
-    # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+    config.exception_level_filters.merge!(
+      'MyCriticalException' => 'critical',
+      'ActionController::RoutingError' => lambda do |e|
+        # Ignore /*.php, /*.xml, *.yml, .txt because they're just probing for security holes
+        e.message.match(/No route matches \[GET\] "\/.*\.(php|xml|yml|txt|png)"/) ? 'ignore' : 'warning'
+      end
+    )
     #
     # You can also specify a callable, which will be called with the exception instance.
     # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })


### PR DESCRIPTION
Eviter un crash si un enfant n'a pas de fiche de suivi lors d'un envoi de message
Ignorer les erreurs ActionController::RoutingError terminant par .php, .xml, .yml, .txt, .png pour éviter de trop nombreuses erreurs causées par des robots.