### PR TITLE
Stop familles désengagées T1

### DIFF
--- a/app/jobs/child_support/assign_default_call_status_job.rb
+++ b/app/jobs/child_support/assign_default_call_status_job.rb
@@ -1,0 +1,8 @@
+require 'sidekiq-scheduler'
+class ChildSupport
+    class AssignDefaultCallStatusJob < ApplicationJob
+      def perform(group_id, call_number)
+        ChildSupport::AssignDefaultCallStatusService.new(group_id, call_number).call
+    end
+  end
+end

--- a/app/jobs/children_support_module/select_module_job.rb
+++ b/app/jobs/children_support_module/select_module_job.rb
@@ -64,7 +64,7 @@ class ChildrenSupportModule
     def add_t1_disengagement_tag_to_child(child)
       family_responded_to_call_statuses = [I18n.t('activerecord.attributes.child_support/call_status.1_ok'), I18n.t('activerecord.attributes.child_support/call_status.5_unfinished')]
       return if [child.child_support.call0_status, child.child_support.call1_status, child.child_support.call2_status].any? do |status|
-        status.in?(family_responded_to_call_statuses)
+        status.in?(family_responded_to_call_statuses) || status.blank?
       end
 
       child.child_support.tag_list.add('estimées-désengagées-T1')

--- a/app/jobs/children_support_module/select_module_job.rb
+++ b/app/jobs/children_support_module/select_module_job.rb
@@ -29,7 +29,10 @@ class ChildrenSupportModule
 
         next if child.siblings_on_same_group.count > 1 && child.child_support.current_child != child
 
-        add_disengagement_tag_to_child(child) if check_disengagement?(group, module_index)
+        # add "estimées-désengagées-T1" tag to families that didn't answer any call 0->2 (if module_index = 2)
+        add_t1_disengagement_tag_to_child(child) if check_t1_disengagement?(group, module_index)
+        # add "estimé-desengagé" tag to families that didn't chose module 3 & didnt answer call 3 (if module_index = 4)
+        add_module4_disengagement_tag_to_child(child) if check_module4_disengagement?(group, module_index)
 
         child.child_support.update(
           parent1_available_support_module_list: child.child_support.parent1_available_support_module_list&.reject(&:blank?)&.first(3),
@@ -49,7 +52,7 @@ class ChildrenSupportModule
 
     private
 
-    def add_disengagement_tag_to_child(child)
+    def add_module4_disengagement_tag_to_child(child)
       return if [I18n.t('activerecord.attributes.child_support/call_status.1_ok'), I18n.t('activerecord.attributes.child_support/call_status.5_unfinished')].include? child.child_support.call3_status
 
       return if child.child_support.module3_chosen_by_parents
@@ -58,12 +61,26 @@ class ChildrenSupportModule
       child.child_support.save!
     end
 
-    def check_disengagement?(group, module_index)
+    def add_t1_disengagement_tag_to_child(child)
+      family_responded_to_call_statuses = [I18n.t('activerecord.attributes.child_support/call_status.1_ok'), I18n.t('activerecord.attributes.child_support/call_status.5_unfinished')]
+      return if [child.child_support.call0_status, child.child_support.call1_status, child.child_support.call2_status].any? do |status|
+        status.in?(family_responded_to_call_statuses)
+      end
+
+      child.child_support.tag_list.add('estimées-désengagées-T1')
+      child.child_support.save!
+    end
+
+    def check_module4_disengagement?(group, module_index)
       return true if group.id == ENV['MAY_GROUP_ID'].to_i && module_index == 4
 
       return true if group.id == ENV['JUNE_GROUP_ID'].to_i && module_index == 6
 
       (group.with_module_zero? && module_index == 5) || (!group.with_module_zero? && module_index == 4 && group.started_at > DateTime.parse(ENV['DISENGAGEMENT_FEATURE_START_DATE']))
+    end
+
+    def check_t1_disengagement?(group, module_index)
+      module_index.eql?(3) && group.with_module_zero?
     end
   end
 end

--- a/app/models/child_support.rb
+++ b/app/models/child_support.rb
@@ -359,7 +359,7 @@ class ChildSupport < ApplicationRecord
   def self.create_call_status_ransacker(call)
     ransacker :"#{call}_status_filter", formatter: proc { |value|
       results = ChildSupport.where("#{call}_status": value).map(&:id) if value.in?(ChildSupport::CALL_STATUS.map { |v| ChildSupport.human_attribute_name("call_status.#{v}") })
-      results = ChildSupport.where("#{call}_status": nil).map(&:id) if value == 'nil'
+      results = ChildSupport.where("#{call}_status": [nil, '']).map(&:id) if value == 'nil'
       results
     } do |parent|
       parent.table[:id]

--- a/app/services/child_support/assign_default_call_status_service.rb
+++ b/app/services/child_support/assign_default_call_status_service.rb
@@ -1,0 +1,42 @@
+class ChildSupport::AssignDefaultCallStatusService
+
+	def initialize(group_id, call_number)
+		@group = Group.find(group_id)
+		@call_number = call_number.to_i
+	end
+  
+	def call
+		ChildSupport.includes(:children).where(children: { id: @group.children.active_group.map(&:id) }).where("call#{@call_number}_status".to_sym => [nil, '']).uniq.each do |child_support|
+			call_status =
+				case @call_number
+				when 2
+					default_call2_status(child_support)
+				else
+					default_call_status(child_support)
+				end
+				status_details = "Appel automatiquement passé en statut #{call_status} le #{Time.zone.now.strftime("%d/%m/%Y à %H:%M")}\n\n"
+				status_details += child_support.send("call#{@call_number}_status_details") || ''
+			child_support.update("call#{@call_number}_status" => call_status, "call#{@call_number}_status_details" => status_details)
+		end
+		self
+	end
+  
+	private
+
+	def default_call2_status(child_support)
+		if child_support.send("call#{@call_number}_notes").blank? && child_support.send("call#{@call_number}_duration").blank? &&
+			child_support.current_child.children_support_modules.not_programmed.last&.support_module_id.nil?
+			'KO'
+		else
+			'OK'
+		end
+	end
+
+	def default_call_status(child_support)
+		if child_support.send("call#{@call_number}_notes").blank? && child_support.send("call#{@call_number}_duration").blank?
+			'KO'
+		else
+			'OK'
+		end
+	end
+end

--- a/app/services/child_support/children_disengagement_service.rb
+++ b/app/services/child_support/children_disengagement_service.rb
@@ -6,7 +6,7 @@ class ChildSupport::ChildrenDisengagementService
 
   def call
     ChildSupport.includes(:children).where(children: { id: @group.children.map(&:id) }).tagged_with('estimé-desengagé').uniq.each do |child_support|
-      if module_chosen(child_support, @group.id)
+      if module4_chosen(child_support, @group.id)
         child_support.tag_list = child_support.tag_list.map { |tag| tag == 'estimé-desengagé' ? 'estimé-desengagé-conservé' : tag }
       else
         child_support.tag_list = child_support.tag_list.map { |tag| tag == 'estimé-desengagé' ? 'desengagé' : tag }
@@ -16,7 +16,7 @@ class ChildSupport::ChildrenDisengagementService
     end
 
     ChildSupport.includes(:children).where(children: { id: @group.children.map(&:id) }).tagged_with('estimées-désengagées-T1').uniq.each do |child_support|
-      if module_chosen(child_support, @group.id)
+      if module2_chosen(child_support)
         child_support.tag_list = child_support.tag_list.map { |tag| tag == 'estimées-désengagées-T1' ? 'estimées-désengagées-T1-conservées' : tag }
       else
         child_support.tag_list = child_support.tag_list.map { |tag| tag == 'estimées-désengagées-T1' ? 'désengagées-T1' : tag }
@@ -28,11 +28,15 @@ class ChildSupport::ChildrenDisengagementService
 
   private
 
-  def module_chosen(child_support, group_id)
+  def module4_chosen(child_support, group_id)
     if group_id == ENV['JUNE_GROUP_ID'].to_i
       child_support.module6_chosen_by_parents
     else
       child_support.module4_chosen_by_parents
     end
+  end
+
+  def module2_chosen(child_support)
+    child_support.module2_chosen_by_parents
   end
 end

--- a/app/services/child_support/children_disengagement_service.rb
+++ b/app/services/child_support/children_disengagement_service.rb
@@ -14,6 +14,16 @@ class ChildSupport::ChildrenDisengagementService
       end
       child_support.save
     end
+
+    ChildSupport.includes(:children).where(children: { id: @group.children.map(&:id) }).tagged_with('estimées-désengagées-T1').uniq.each do |child_support|
+      if module_chosen(child_support, @group.id)
+        child_support.tag_list = child_support.tag_list.map { |tag| tag == 'estimées-désengagées-T1' ? 'estimées-désengagées-T1-conservées' : tag }
+      else
+        child_support.tag_list = child_support.tag_list.map { |tag| tag == 'estimées-désengagées-T1' ? 'désengagées-T1' : tag }
+        child_support.children.update(group_status: 'disengaged', group_end: Time.zone.today)
+      end
+      child_support.save
+    end
   end
 
   private

--- a/app/services/child_support/select_module_service.rb
+++ b/app/services/child_support/select_module_service.rb
@@ -25,6 +25,7 @@ class ChildSupport::SelectModuleService
   private
 
   def send_select_module_message(parent, available_support_module_list)
+    return if available_support_module_list.blank?
     return if available_support_module_list.reject(&:blank?).empty?
 
     @children_support_module = ChildrenSupportModule.find_by(child_id: @child.id, parent_id: parent.id, is_programmed: false)

--- a/app/services/child_support/select_module_service.rb
+++ b/app/services/child_support/select_module_service.rb
@@ -49,6 +49,8 @@ class ChildSupport::SelectModuleService
 
     message = if @child.child_support.tag_list.include?('estimé-desengagé')
                 "1001mots: C’est le moment de choisir votre prochain thème pour #{@child.first_name} en cliquant sur le lien #{selection_link}. Si vous ne faites pas de choix, l’accompagnement 1001mots prendra fin."
+              elsif @child.child_support.tag_list.include?('estimées-désengagées-T1')
+                "1001mots : Cliquez sur le lien pour choisir votre prochain thème pour #{@child.first_name} et recevoir un nouveau livre. Attention l'accompagnement s'arrêtera si vous ne choisissez pas avant la fin de semaine. #{selection_link}"
               else
                 "1001mots : Cliquez sur le lien pour choisir votre prochain thème pour #{@child.first_name} et recevoir un nouveau livre. Attention dans #{date}, nous choisirons à votre place ! #{selection_link}"
               end

--- a/app/services/children_support_module/send_reminder.rb
+++ b/app/services/children_support_module/send_reminder.rb
@@ -24,7 +24,7 @@ class ChildrenSupportModule
           "1001mots : pour recevoir le prochain livre de 1001mots pour #{@child.first_name}, n'oubliez pas de choisir votre thème en cliquant sur ce lien : #{selection_link}"
         end
 
-      message += '. Si vous ne faites pas de choix, l’accompagnement 1001mots prendra fin.' if @child.child_support.tag_list.include?('estimé-desengagé')
+      message += '. Si vous ne faites pas de choix, l’accompagnement 1001mots prendra fin.' if (@child.child_support.tag_list & ['estimé-desengagé', 'estimées-désengagées-T1']).present?
 
       sms_service = ProgramMessageService.new(
         @reminder_date,

--- a/app/services/group/add_t1_disengagement_tag_service.rb
+++ b/app/services/group/add_t1_disengagement_tag_service.rb
@@ -1,0 +1,18 @@
+class Group::AddT1DisengagementTagService
+	attr_reader
+
+	def initialize(group_id)
+		@child_supports = ChildSupport.group_id_in(group_id).with_a_child_in_active_group.
+																	 where('call0_status IN (?, ?)', 'KO', 'Ne pas appeler').
+																	 where('call1_status IN (?, ?)', 'KO', 'Ne pas appeler').
+																	 where('call2_status IN (?, ?)', 'KO', 'Ne pas appeler')
+	end
+  
+	def call
+		@child_supports.each do |child_support|
+			child_support.tag_list.add('estimées-désengagées-T1')
+      child_support.save!
+		end
+		self
+	end
+end

--- a/app/services/group/get_scheduled_jobs_service.rb
+++ b/app/services/group/get_scheduled_jobs_service.rb
@@ -52,6 +52,8 @@ class Group
 
       name = if job_class_name == ChildrenSupportModule::SelectModuleJob.to_s && job.args[0]['arguments']&.third.eql?(@group_with_module_zero ? 3 : 2)
                "Programmation des SMS de choix du module aux parents n'ayant pas reçu d'appel 2"
+             elsif job_class_name == ChildSupport::AssignDefaultCallStatusJob.to_s
+               "Assignation d'un statut par défaut aux appels #{job.args[0]['arguments']&.second} laissés vides"
              else
                GROUP_JOB_CLASS_NAMES[job_class_name]
              end

--- a/app/services/group/get_scheduled_jobs_service.rb
+++ b/app/services/group/get_scheduled_jobs_service.rb
@@ -10,6 +10,7 @@ class Group
       ChildrenSupportModule::ProgramSupportModuleZeroJob.to_s => 'Programmation du module zero',
       Group::ProgramSmsToBilingualsJob.to_s => 'Programmation des messages aux familles bilingues',
       ChildrenSupportModule::ProgramFirstSupportModuleJob.to_s => 'Programmation du 1er module',
+      ChildSupport::AssignDefaultCallStatusJob.to_s => "Assignation d'un statut d'appel par défaut en cas d'absence",
       ChildrenSupportModule::FillParentsAvailableSupportModulesJob.to_s => 'Ajout des modules disponibles sur les fiches de suivi',
       ChildrenSupportModule::VerifyAvailableModulesTaskJob.to_s => 'Vérification que tous les enfants ont des modules disponibles sur leur fiche de suivi',
       ChildrenSupportModule::CreateChildrenSupportModuleJob.to_s => 'Préparation préalable au choix des parents pour l’appel 2',

--- a/app/services/group/program_service.rb
+++ b/app/services/group/program_service.rb
@@ -74,13 +74,13 @@ class Group
       default_status_date =
         case call_number
         when 0
-          @group.started_at + 3.weeks
+          @group.started_at + 2.weeks
         when 1
-          @group.started_at + 7.weeks
+          @group.started_at + 6.weeks
         when 2
-          @group.started_at + 11.weeks
+          @group.started_at + 10.weeks
         when 3
-          @group.started_at + 26.weeks
+          @group.started_at + 25.weeks
         end
       ChildSupport::AssignDefaultCallStatusJob.set(wait_until: default_status_date.to_datetime.change(hour: @hour - 1)).perform_later(@group.id, call_number)
     end


### PR DESCRIPTION
https://trello.com/c/OyEcDsEJ/254-r%C3%A8gles-darr%C3%AAt-des-familles-d%C3%A9sengag%C3%A9es-%C3%A0-3-mois

https://trello.com/c/h0sZNYrX/255-assigner-un-statut-dappel-par-d%C3%A9faut-si-vide-en-fin-de-p%C3%A9riode-dappel

⚠️ Il faut programmer les jobs d'assignation par défaut des statuts d'appels aux cohortes en cours