### PR TITLE
Assignation par défaut des statuts d'appel en cas d'absence + tweaks

### DIFF
--- a/app/jobs/child_support/assign_default_call_status_job.rb
+++ b/app/jobs/child_support/assign_default_call_status_job.rb
@@ -1,0 +1,8 @@
+require 'sidekiq-scheduler'
+class ChildSupport
+    class AssignDefaultCallStatusJob < ApplicationJob
+      def perform(group_id, call_number)
+        ChildSupport::AssignDefaultCallStatusService.new(group_id, call_number).call
+    end
+  end
+end

--- a/app/jobs/children_support_module/select_module_job.rb
+++ b/app/jobs/children_support_module/select_module_job.rb
@@ -64,7 +64,7 @@ class ChildrenSupportModule
     def add_t1_disengagement_tag_to_child(child)
       family_responded_to_call_statuses = [I18n.t('activerecord.attributes.child_support/call_status.1_ok'), I18n.t('activerecord.attributes.child_support/call_status.5_unfinished')]
       return if [child.child_support.call0_status, child.child_support.call1_status, child.child_support.call2_status].any? do |status|
-        status.in?(family_responded_to_call_statuses)
+        status.in?(family_responded_to_call_statuses) || status.blank?
       end
 
       child.child_support.tag_list.add('estimées-désengagées-T1')

--- a/app/models/child_support.rb
+++ b/app/models/child_support.rb
@@ -359,7 +359,7 @@ class ChildSupport < ApplicationRecord
   def self.create_call_status_ransacker(call)
     ransacker :"#{call}_status_filter", formatter: proc { |value|
       results = ChildSupport.where("#{call}_status": value).map(&:id) if value.in?(ChildSupport::CALL_STATUS.map { |v| ChildSupport.human_attribute_name("call_status.#{v}") })
-      results = ChildSupport.where("#{call}_status": nil).map(&:id) if value == 'nil'
+      results = ChildSupport.where("#{call}_status": [nil, '']).map(&:id) if value == 'nil'
       results
     } do |parent|
       parent.table[:id]

--- a/app/services/child_support/assign_default_call_status_service.rb
+++ b/app/services/child_support/assign_default_call_status_service.rb
@@ -1,0 +1,42 @@
+class ChildSupport::AssignDefaultCallStatusService
+
+	def initialize(group_id, call_number)
+		@group = Group.find(group_id)
+		@call_number = call_number.to_i
+	end
+  
+	def call
+		ChildSupport.includes(:children).where(children: { id: @group.children.active_group.map(&:id) }).where("call#{@call_number}_status".to_sym => [nil, '']).uniq.each do |child_support|
+			call_status =
+				case @call_number
+				when 2
+					default_call2_status(child_support)
+				else
+					default_call_status(child_support)
+				end
+				status_details = "Appel automatiquement passé en statut #{call_status} le #{Time.zone.now.strftime("%d/%m/%Y à %H:%M")}\n\n"
+				status_details += child_support.send("call#{@call_number}_status_details") || ''
+			child_support.update("call#{@call_number}_status" => call_status, "call#{@call_number}_status_details" => status_details)
+		end
+		self
+	end
+  
+	private
+
+	def default_call2_status(child_support)
+		if child_support.send("call#{@call_number}_notes").blank? && child_support.send("call#{@call_number}_duration").blank? &&
+			child_support.current_child.children_support_modules.not_programmed.last&.support_module_id.nil?
+			'KO'
+		else
+			'OK'
+		end
+	end
+
+	def default_call_status(child_support)
+		if child_support.send("call#{@call_number}_notes").blank? && child_support.send("call#{@call_number}_duration").blank?
+			'KO'
+		else
+			'OK'
+		end
+	end
+end

--- a/app/services/child_support/select_module_service.rb
+++ b/app/services/child_support/select_module_service.rb
@@ -25,6 +25,7 @@ class ChildSupport::SelectModuleService
   private
 
   def send_select_module_message(parent, available_support_module_list)
+    return if available_support_module_list.blank?
     return if available_support_module_list.reject(&:blank?).empty?
 
     @children_support_module = ChildrenSupportModule.find_by(child_id: @child.id, parent_id: parent.id, is_programmed: false)

--- a/app/services/group/get_scheduled_jobs_service.rb
+++ b/app/services/group/get_scheduled_jobs_service.rb
@@ -10,6 +10,7 @@ class Group
       ChildrenSupportModule::ProgramSupportModuleZeroJob.to_s => 'Programmation du module zero',
       Group::ProgramSmsToBilingualsJob.to_s => 'Programmation des messages aux familles bilingues',
       ChildrenSupportModule::ProgramFirstSupportModuleJob.to_s => 'Programmation du 1er module',
+      ChildSupport::AssignDefaultCallStatusJob.to_s => "Assignation d'un statut d'appel par défaut en cas d'absence",
       ChildrenSupportModule::FillParentsAvailableSupportModulesJob.to_s => 'Ajout des modules disponibles sur les fiches de suivi',
       ChildrenSupportModule::VerifyAvailableModulesTaskJob.to_s => 'Vérification que tous les enfants ont des modules disponibles sur leur fiche de suivi',
       ChildrenSupportModule::CreateChildrenSupportModuleJob.to_s => 'Préparation préalable au choix des parents pour l’appel 2',


### PR DESCRIPTION
https://trello.com/c/h0sZNYrX/255-assigner-un-statut-dappel-par-d%C3%A9faut-si-vide-en-fin-de-p%C3%A9riode-dappel

⚠️ Il faut programmer les jobs d'assignation par défaut des statuts d'appels aux cohortes en cours