### PR TITLE
Fonctionnalité parents blacklistés des ateliers (#762)

### DIFF
--- a/app/admin/parent.rb
+++ b/app/admin/parent.rb
@@ -47,6 +47,7 @@ ActiveAdmin.register Parent do
   filter :first_name
   filter :last_name
   filter :phone_number
+  filter :is_excluded_from_workshop
   filter :family_followed, as: :check_boxes
   filter :present_on_whatsapp
   filter :present_on_facebook
@@ -76,6 +77,7 @@ ActiveAdmin.register Parent do
       f.input :last_name
       f.input :phone_number,
         input_html: { value: f.object.decorate.phone_number }
+      f.input :is_excluded_from_workshop
       f.input :family_followed
       f.input :present_on_whatsapp
       f.input :present_on_facebook
@@ -93,7 +95,7 @@ ActiveAdmin.register Parent do
   end
 
   permit_params :gender, :first_name, :last_name,
-    :phone_number, :present_on_whatsapp, :present_on_facebook, :follow_us_on_facebook, :follow_us_on_whatsapp, :email,
+    :phone_number, :is_excluded_from_workshop, :present_on_whatsapp, :present_on_facebook, :follow_us_on_facebook, :follow_us_on_whatsapp, :email,
     :letterbox_name, :address, :postal_code, :city_name,
     :is_ambassador, :job, :terms_accepted_at, :family_followed,
     tags_params
@@ -112,6 +114,7 @@ ActiveAdmin.register Parent do
           row :first_name
           row :last_name
           row :phone_number
+          row :is_excluded_from_workshop
           row :family_followed
           row :present_on_whatsapp
           row :present_on_facebook

--- a/app/admin/workshop.rb
+++ b/app/admin/workshop.rb
@@ -42,7 +42,7 @@ ActiveAdmin.register Workshop do
       f.input :co_animator
       address_input f
       f.input :location
-      f.input :parents, collection: parent_select_collection, input_html: { data: { select2: {} }, disabled: !object.new_record? }
+      f.input :parents, collection: workshop_parent_select_collection, input_html: { data: { select2: {} }, disabled: !object.new_record? }
       f.input :workshop_land, collection: Child::LANDS.sort, input_html: { data: { select2: {} }, disabled: !object.new_record? }
       f.input :invitation_message, input_html: { rows: 5, disabled: !object.new_record? }
       f.input :canceled
@@ -123,7 +123,7 @@ ActiveAdmin.register Workshop do
   member_action :perform_parents_registration, method: :post do
     workshop = Workshop.find(params[:workshop_id])
     parent_to_register_ids = params[:workshop][:parent_ids].reject(&:blank?)
-    parents_to_register = Parent.where(id: parent_to_register_ids)
+    parents_to_register = Parent.not_excluded_from_workshop.where(id: parent_to_register_ids)
     workshop.parents << parents_to_register
 
     parents_to_register.each do |parent|

--- a/app/helpers/active_admin/parents_helper.rb
+++ b/app/helpers/active_admin/parents_helper.rb
@@ -9,7 +9,7 @@ module ActiveAdmin::ParentsHelper
     end
   end
 
-  def parent_select_collection
-    Parent.order(:id).map(&:decorate)
+  def workshop_parent_select_collection
+    Parent.not_excluded_from_workshop.order(:id).map(&:decorate)
   end
 end

--- a/app/jobs/child/update_children_workshop_availability_job.rb
+++ b/app/jobs/child/update_children_workshop_availability_job.rb
@@ -6,9 +6,9 @@ class Child::UpdateChildrenWorkshopAvailabilityJob < ApplicationJob
     Child.update_all(available_for_workshops: false)
 
     if Time.zone.today.month <= 8
-      Child.where(birthdate: Date.new(Time.zone.today.year - 3, 1, 1)..Date.new(Time.zone.today.year, 12, 31)).update_all(available_for_workshops: true)
+      Child.supported.where(birthdate: Date.new(Time.zone.today.year - 3, 1, 1)..Date.new(Time.zone.today.year, 12, 31)).update_all(available_for_workshops: true)
     else
-      Child.where(birthdate: Date.new(Time.zone.today.year - 2, 1, 1)..Date.new(Time.zone.today.year, 12, 31)).update_all(available_for_workshops: true)
+      Child.supported.where(birthdate: Date.new(Time.zone.today.year - 2, 1, 1)..Date.new(Time.zone.today.year, 12, 31)).update_all(available_for_workshops: true)
     end
   end
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -162,6 +162,7 @@ class Child < ApplicationRecord
   scope :potential_duplicates, -> {
     where('(unaccent(children.first_name), unaccent(children.last_name), children.birthdate) IN (SELECT unaccent(first_name), unaccent(last_name), birthdate FROM children GROUP BY unaccent(children.first_name), unaccent(children.last_name), children.birthdate HAVING COUNT(*) > 1)')
   }
+  scope :supported, -> { where.not(group_status: 'not_supported') }
 
   def self.without_group_and_not_waiting_second_group
     second_group_children_ids = Child.tagged_with('2eme cohorte').pluck(:id)

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -16,6 +16,7 @@
 #  gender                              :string           not null
 #  help_my_child_to_learn_is_important :string
 #  is_ambassador                       :boolean
+#  is_excluded_from_workshop           :boolean          default(FALSE)
 #  job                                 :string
 #  last_name                           :string           not null
 #  letterbox_name                      :string
@@ -221,6 +222,14 @@ class Parent < ApplicationRecord
 
   def self.fathers
     where(gender: GENDER_MALE)
+  end
+
+  def self.not_excluded_from_workshop
+    where(is_excluded_from_workshop: false)
+  end
+
+  def self.excluded_from_workshop
+    where(is_excluded_from_workshop: true)
   end
 
   def children

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -62,6 +62,8 @@ class Workshop < ApplicationRecord
 
   def set_workshop_participation
     land_parents.each do |parent|
+      next if parent.is_excluded_from_workshop
+
       next unless parent.available_for_workshops?
 
       next unless parent.should_be_contacted?
@@ -77,6 +79,8 @@ class Workshop < ApplicationRecord
     end
 
     (parents.to_a - land_parents.to_a).each do |parent|
+      next if parent.is_excluded_from_workshop
+
       workshop_participations.build(
         type: 'Events::WorkshopParticipation',
         related: parent,

--- a/app/views/admin/workshops/register_parents.erb
+++ b/app/views/admin/workshops/register_parents.erb
@@ -9,7 +9,7 @@
     <%= f.input :parents,
                 multiple: true,
                 label: "Parents",
-                collection: parent_select_collection,
+                collection: workshop_parent_select_collection,
                 input_html: {
                   data: {
                     select2: {

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -492,6 +492,7 @@ fr:
         children_count: Enfants
         city_name: Ville
         email: Email
+        is_excluded_from_workshop: Exclu des ateliers
         first_name: Prénom
         gender: Sexe
         is_ambassador: Potentiel parent ambassadeur

--- a/db/migrate/20240325105535_add_exclude_to_workshop_to_parents.rb
+++ b/db/migrate/20240325105535_add_exclude_to_workshop_to_parents.rb
@@ -1,0 +1,5 @@
+class AddExcludeToWorkshopToParents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :parents, :is_excluded_from_workshop, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_23_133409) do
+ActiveRecord::Schema.define(version: 2024_03_25_105535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -480,6 +480,7 @@ ActiveRecord::Schema.define(version: 2024_02_23_133409) do
     t.integer "mid_term_rate"
     t.string "mid_term_reaction"
     t.text "mid_term_speech"
+    t.boolean "is_excluded_from_workshop", default: false
     t.index ["address"], name: "index_parents_on_address"
     t.index ["city_name"], name: "index_parents_on_city_name"
     t.index ["discarded_at"], name: "index_parents_on_discarded_at"

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -16,6 +16,7 @@
 #  gender                              :string           not null
 #  help_my_child_to_learn_is_important :string
 #  is_ambassador                       :boolean
+#  is_excluded_from_workshop           :boolean          default(FALSE)
 #  job                                 :string
 #  last_name                           :string           not null
 #  letterbox_name                      :string

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -87,9 +87,33 @@ RSpec.describe Workshop, type: :model do
     end
   end
 
-  # describe ".set_workshop_participation" do
-  #   context "create workshop_participation for each parent invited" do
-  #
-  #   end
-  # end
+  describe ".set_workshop_participation" do
+    before do
+      stub_request(:post, 'https://www.spot-hit.fr/api/envoyer/sms').
+        to_return(status: 200, body: '{}')
+    end
+
+    context "create workshop_participation for each parent invited" do
+      let!(:group) { FactoryBot.create(:group) }
+      let!(:first_excluded_parent) { FactoryBot.create(:parent, is_excluded_from_workshop: true) }
+      let!(:first_parent) { FactoryBot.create(:parent, postal_code: 75018) }
+      let!(:second_parent) { FactoryBot.create(:parent, postal_code: 75018) }
+      let!(:second_excluded_parent) { FactoryBot.create(:parent, is_excluded_from_workshop: true, postal_code: 75018) }
+
+      let!(:first_child) { FactoryBot.create(:child, available_for_workshops: true, should_contact_parent1: true, group: group, group_status: 'active') }
+      let!(:second_child) { FactoryBot.create(:child, available_for_workshops: true, should_contact_parent1: true, group: group, group_status: 'active', parent1: first_excluded_parent) }
+      let!(:third_child) { FactoryBot.create(:child, available_for_workshops: true, should_contact_parent1: true, group: group, group_status: 'active', parent1: first_parent) }
+      let!(:fourth_child) { FactoryBot.create(:child, available_for_workshops: true, should_contact_parent1: true, group: group, group_status: 'active', parent1: second_parent) }
+      let!(:fifth_child) { FactoryBot.create(:child, available_for_workshops: true, should_contact_parent1: true, group: group, group_status: 'active', parent1: second_excluded_parent) }
+      let!(:workshop) { FactoryBot.create(:workshop, parents: [first_child.parent1, first_excluded_parent ], workshop_land: 'Paris 18 eme') }
+
+      it "except parents with is_excluded_from_workshop at true" do
+        expect(Events::WorkshopParticipation.exists?(related: first_excluded_parent)).to be_falsey
+        expect(Events::WorkshopParticipation.exists?(related: second_excluded_parent)).to be_falsey
+        expect(Events::WorkshopParticipation.exists?(related: first_parent)).to be_truthy
+        expect(Events::WorkshopParticipation.exists?(related: second_parent)).to be_truthy
+        expect(Events::WorkshopParticipation.exists?(related: first_child.parent1)).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
* feature(workshop) : Preventing the invitation of certain parents to the workshops.

* refactoring(workshop) : Replace excluded_from_workshop by is_excluded_from_workshop.

* feature(workshop) : Parents excluded from workshop are not selectable

* feature(available_for_workshops) : Child not supported are not available for workshops