### PR TITLE
Enfants : retirer la cohorte si statut est "Non accompagné" + autres tweaks

### DIFF
--- a/app/admin/child.rb
+++ b/app/admin/child.rb
@@ -48,6 +48,7 @@ ActiveAdmin.register Child do
   end
 
   scope :all, default: true
+  scope :supported
 
   scope :active_group, group: :group
   scope :without_group, group: :group

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -145,6 +145,7 @@ class Child < ApplicationRecord
   after_create :create_support!
   after_create :add_to_group
   after_update :update_support
+  after_update :remove_group, if: -> { saved_change_to_group_status? && group_status.eql?('not_supported') }
 
   # ---------------------------------------------------------------------------
   # scopes
@@ -701,5 +702,12 @@ class Child < ApplicationRecord
     else
       diff
     end
+  end
+
+  def remove_group
+    return unless group_id
+
+    self.group_id = nil
+    save(validate: false)
   end
 end

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -81,3 +81,4 @@ fr:
       without_choice: Pas encore choisi
       account_disabled: Compte désactivé
       account_not_disabled: Compte actif
+      supported: Inscrits ou accompagnés

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -86,7 +86,7 @@ fr:
         gender: Sexe
         group: Cohorte
         child_group_name: Cohorte
-        group_status: Statut de la cohorte
+        group_status: Statut
         land: Terrain
         territory: Territoire
         last_name: Nom
@@ -131,9 +131,9 @@ fr:
         x: Inconnu
       child/group_status:
         waiting: En attente
-        active: Active
+        active: Actif
         paused: En pause
-        stopped: Arrêtée
+        stopped: Arrêté
         disengaged: Désengagé
         not_supported: Non accompagné
       children_support_module:
@@ -545,7 +545,7 @@ fr:
         child_first_name: "Prénom de l'enfant"
         child_gender: "Sexe de l'enfant"
         child_group_name: Cohorte
-        child_group_status: Statut de la cohorte
+        child_group_status: "Statut de l'enfant"
         child_last_name: "Nom de l'enfant"
         parent: Parent
         parent_address: Adresse


### PR DESCRIPTION
https://trello.com/c/cTswoCZZ/264-retirer-la-cohorte-des-enfants-avec-statut-non-accompagn%C3%A9
https://trello.com/c/iVUzDfwb/265-modifier-le-wording-du-champ-statut-de-la-cohorte
https://trello.com/c/RKnHLxE2/268-ajouter-une-vue-enfants-inscrits-ou-accompagn%C3%A9s-dans-le-menu-enfants-sans-les-non-accompagn%C3%A9s