### PR TITLE
Expérience appelante

### DIFF
--- a/app/admin/child_support.rb
+++ b/app/admin/child_support.rb
@@ -18,6 +18,7 @@ ActiveAdmin.register ChildSupport do
     selectable_column
     id_column
     column :children
+    column :supporter if current_admin_user.admin? || current_admin_user.team_member? || current_admin_user.logistics_team?
     (0..5).each do |call_idx|
       column "Appel #{call_idx}" do |decorated|
         [
@@ -251,8 +252,8 @@ ActiveAdmin.register ChildSupport do
           end
         end
         column class: 'column flex-column' do
-          available_support_module_input(f, :parent1_available_support_module_list)
-          available_support_module_input(f, :parent2_available_support_module_list) unless resource.parent2.nil?
+          available_support_module_input(f, :parent1_available_support_module_list, current_admin_user.caller?)
+          available_support_module_input(f, :parent2_available_support_module_list, current_admin_user.caller?) unless resource.parent2.nil?
           div class: 'border' do
             span "Ces informations apparaissent dans l'index des suivis"
             f.input :availability, input_html: { style: 'width: 70%' }

--- a/app/decorators/child_support_decorator.rb
+++ b/app/decorators/child_support_decorator.rb
@@ -113,7 +113,7 @@ class ChildSupportDecorator < BaseDecorator
     children_attribute(:group_name, glue)
   end
 
-  (1..5).each do |call_idx|
+  (0..5).each do |call_idx|
 
     define_method("call#{call_idx}_parent_progress_index") do
       progress model.send("call#{call_idx}_parent_progress_index")

--- a/app/helpers/active_admin/support_modules_helper.rb
+++ b/app/helpers/active_admin/support_modules_helper.rb
@@ -7,11 +7,12 @@ module ActiveAdmin::SupportModulesHelper
     support_modules&.sort_by { |e| selected_values&.index(e[1]) || Float::INFINITY }
   end
 
-  def available_support_module_input(form, input_name, options = {})
+  def available_support_module_input(form, input_name, disabled, options = {})
     input_html = {
       data: {
         select2: {}
-      }
+      },
+      disabled: disabled
     }
 
     selected_values = form.object.send(input_name)


### PR DESCRIPTION
- Changer les couleurs des niveaux de pratiques parentales pour l'appel 0 comme pour les appels 1 et 2.
- Afficher la colonne "Responsable" dans l'index des suivis" quand le rôle utilisateur est "membre de l'équipe" ou "administrateur”
- Rendre non modifiable la case "Modules disponibles du parent 1" quand le rôle utilisateur est "Appelante”