### PR TITLE
Enregistrer en DB les paramètres UTM pour mesurer le succès des campagnes d’acquisition

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -145,6 +145,7 @@ class Child < ApplicationRecord
   after_create :create_support!
   after_create :add_to_group
   after_update :update_support
+  after_save { tags.where(is_visible_by_callers: true).where('name ILIKE ?', 'utm%').update(is_visible_by_callers: false) }
   after_update :remove_group, if: -> { saved_change_to_group_status? && group_status.eql?('not_supported') }
 
   # ---------------------------------------------------------------------------

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -21,8 +21,8 @@ class Tag < ActsAsTaggableOn::Tag
   private
 
   def format_name
-    if attribute_present?("name")
-      self.name = I18n.transliterate(name).downcase
-    end
+    return unless attribute_present?('name')
+
+    self.name = I18n.transliterate(name).downcase
   end
 end

--- a/app/services/child/create_service.rb
+++ b/app/services/child/create_service.rb
@@ -61,11 +61,12 @@ class Child
 
     def add_registration_origin_as_tag
       # add tags for bao / local_partner ?
-      @attributes[:tag_list] = case @registration_origin
-                               when 3 then ['form-pro']
-                               when 2 then ['form-2']
-                               else ['site']
-                               end
+      @attributes[:tag_list] ||= []
+      @attributes[:tag_list] << case @registration_origin
+                                when 3 then 'form-pro'
+                                when 2 then 'form-2'
+                                else 'site'
+                                end
     end
 
     def add_target_tag_and_handle_children_not_supported
@@ -86,8 +87,8 @@ class Child
       @attributes[:child_support_attributes] ||= {}
       @attributes[:child_support_attributes][:tag_list] ||= []
       @attributes[:tag_list] << tag
-      @parent1_attributes[:tag_list] << tag
-      @parent2_attributes[:tag_list] << tag
+      @parent1_attributes[:tag_list] += @attributes[:tag_list]
+      @parent2_attributes[:tag_list] += @attributes[:tag_list]
       @attributes[:child_support_attributes][:tag_list] << tag
     end
 

--- a/app/views/children/_child_form.html.erb
+++ b/app/views/children/_child_form.html.erb
@@ -2,6 +2,7 @@
 <%= f.input :first_name %>
 <%= f.input :last_name %>
 <%= f.input :birthdate, start_year: @child_min_birthdate.year, end_year: Child.max_birthdate.year %>
+<%= f.input :tag_list, as: :hidden %>
 
 <% if defined?(with_support) && with_support %>
   <%= f.simple_fields_for :child_support do |child_support_f| %>

--- a/spec/requests/children_spec.rb
+++ b/spec/requests/children_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe ChildrenController, type: :request do
             "birthdate(3i)" => birthdate.day.to_s,
             "birthdate(2i)" => birthdate.month.to_s,
             "birthdate(1i)" => birthdate.year.to_s,
+            tag_list: "",
             child_support_attributes: { important_information: "" },
             parent2_attributes: {
               first_name: "",
@@ -128,6 +129,7 @@ RSpec.describe ChildrenController, type: :request do
             "birthdate(3i)" => birthdate.day.to_s,
             "birthdate(2i)" => birthdate.month.to_s,
             "birthdate(1i)" => birthdate.year.to_s,
+            tag_list: "",
             child_support_attributes: { important_information: "" },
             parent2_attributes: {
               first_name: "",


### PR DESCRIPTION
https://www.notion.so/Enregistrer-en-DB-les-param-tres-UTM-pour-mesurer-le-succ-s-des-campagnes-d-acquisition-2ec9167a7a314e0191a05d2dc08e7c32?pvs=4