### PR TITLE
Events::TextMessage : nouvel attribut pour stocker le substring des liens envoyés aux familles

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -121,6 +121,7 @@ class Event < ApplicationRecord
   private
 
   def extract_link_sent_substring
+    return unless originated_by_app
     return if body.blank?
 
     match = body.match(%r{https://app\.1001mots\.org/r/([^/]+/..)})

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string
@@ -61,6 +62,12 @@ class Event < ApplicationRecord
   validates :occurred_at, presence: true
 
   # ---------------------------------------------------------------------------
+  # callbacks
+  # ---------------------------------------------------------------------------
+
+  before_save :extract_link_sent_substring, if: -> { type.eql?('Events::TextMessage') && will_save_change_to_body? }
+
+  # ---------------------------------------------------------------------------
   # helpers
   # ---------------------------------------------------------------------------
 
@@ -109,5 +116,18 @@ class Event < ApplicationRecord
 
   def self.ransackable_scopes(auth_object = nil)
     %i[parent_current_child_group_id_in parent_current_child_supporter_id_in]
+  end
+
+  private
+
+  def extract_link_sent_substring
+    return if body.blank?
+
+    match = body.match(%r{https://app\.1001mots\.org/r/([^/]+/..)})
+    if match
+      self.link_sent_substring = match[1]
+    else
+      self.link_sent_substring = nil
+    end
   end
 end

--- a/app/models/events/other_event.rb
+++ b/app/models/events/other_event.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string

--- a/app/models/events/survey_response.rb
+++ b/app/models/events/survey_response.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string

--- a/app/models/events/text_message.rb
+++ b/app/models/events/text_message.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string

--- a/app/models/events/workshop_participation.rb
+++ b/app/models/events/workshop_participation.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string

--- a/db/migrate/20241023122454_add_link_sent_substring_to_events.rb
+++ b/db/migrate/20241023122454_add_link_sent_substring_to_events.rb
@@ -1,0 +1,5 @@
+class AddLinkSentSubstringToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :link_sent_substring, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_17_081128) do
+ActiveRecord::Schema.define(version: 2024_10_23_122454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -395,6 +395,7 @@ ActiveRecord::Schema.define(version: 2024_10_17_081128) do
     t.string "parent_presence"
     t.date "acceptation_date"
     t.boolean "is_support_module_message", default: false, null: false
+    t.string "link_sent_substring"
     t.index ["discarded_at"], name: "index_events_on_discarded_at"
     t.index ["quit_group_child_id"], name: "index_events_on_quit_group_child_id"
     t.index ["related_type", "related_id"], name: "index_events_on_related_type_and_related_id"

--- a/lib/tasks/set_link_sent_substring.rake
+++ b/lib/tasks/set_link_sent_substring.rake
@@ -1,0 +1,8 @@
+namespace :events do
+	desc "Sauvegarder le résultat du substring des liens 1001mots présents dans les messages envoyés"
+	task set_link_sent_substring: :environment do
+		Event.sent_by_app_text_messages.where("body LIKE ?", "%https://app.1001mots.org/r/%").update_all(
+			"link_sent_substring = (regexp_match(body, 'https://app\\.1001mots\\.org/r/([^/]+/..)'))[1]"
+		)
+	end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string

--- a/spec/models/events/other_event_spec.rb
+++ b/spec/models/events/other_event_spec.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string

--- a/spec/models/events/survey_response_spec.rb
+++ b/spec/models/events/survey_response_spec.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string

--- a/spec/models/events/text_message_spec.rb
+++ b/spec/models/events/text_message_spec.rb
@@ -7,6 +7,7 @@
 #  body                      :text
 #  discarded_at              :datetime
 #  is_support_module_message :boolean          default(FALSE), not null
+#  link_sent_substring       :string
 #  occurred_at               :datetime
 #  originated_by_app         :boolean          default(TRUE), not null
 #  parent_presence           :string


### PR DESCRIPTION
https://www.notion.so/Stocker-une-nouvelle-donn-e-dans-la-table-Events-pour-permettre-le-suivi-du-de-vid-os-envoy-es-vi-121f8cee65b580c8a40af3a878ca8eed?pvs=4