### PR TITLE
Fixes : pop-up + default module + less rollbar (#950)

### DIFF
--- a/app/jobs/children_support_module/select_default_support_module_job.rb
+++ b/app/jobs/children_support_module/select_default_support_module_job.rb
@@ -20,11 +20,11 @@ class ChildrenSupportModule
           default_support_module_id = csm.available_support_module_list.reject(&:blank?).first
           the_other_parent = csm.parent == csm.child.parent1 ? csm.child.parent2 : csm.child.parent1
           if the_other_parent.present? && the_other_parent.children_support_modules.any?
-            the_other_parent_csm = the_other_parent.children_support_modules.latest_first.first
+            the_other_parent_csm = the_other_parent.children_support_modules.where(child: child).latest_first.first
 
             already_done_support_module_ids = child.children_support_modules.where(parent: csm.parent).pluck(:support_module_id)
 
-            default_support_module_id = the_other_parent_csm.support_module_id if the_other_parent_csm.support_module_id.present? && already_done_support_module_ids.exclude?(the_other_parent_csm.support_module_id)
+            default_support_module_id = the_other_parent_csm.support_module_id if the_other_parent_csm&.support_module_id.present? && already_done_support_module_ids.exclude?(the_other_parent_csm&.support_module_id)
           end
 
           csm.update(support_module_id: default_support_module_id)

--- a/app/models/children_support_module.rb
+++ b/app/models/children_support_module.rb
@@ -201,6 +201,7 @@ class ChildrenSupportModule < ApplicationRecord
 
     child_support = child.child_support
     child_support.send("module#{current_choice_module_number}_chosen_by_parents=", support_module)
-    child_support.save
+    # avoid unnecessary pop-up trigger in child_support edit form
+    child_support.save(touch: false)
   end
 end

--- a/app/services/event/send_message_to_parent_response_service.rb
+++ b/app/services/event/send_message_to_parent_response_service.rb
@@ -20,16 +20,10 @@ class Event::SendMessageToParentResponseService
       return self
     end
 
-    if @parent.message_already_sent_in_response?
-      @errors << 'Message already sent in response'
-      return self
-    end
+    return self if @parent.message_already_sent_in_response?
 
     supporter = @parent.current_child&.child_support&.supporter
-    unless supporter
-      @errors << 'Child has no supporter'
-      return self
-    end
+    return self unless supporter
 
     unless supporter.aircall_phone_number
       @errors << 'Child supporter has no aircall_phone_number'


### PR DESCRIPTION
* fix(child_supports) : avoid pop-up in edit form when we update children support modules

* fix(children_support_modules) : avoid a case where a default support module could be incompatible with a child

* fix(events) : dont return some behavior as an error in class Event::SendMessageToParentResponseService