### PR TITLE
Fix Aircall sync : url sans fiche de suivi

### DIFF
--- a/app/services/aircall/sync_contacts_service.rb
+++ b/app/services/aircall/sync_contacts_service.rb
@@ -65,7 +65,7 @@ module Aircall
 
       child_support_link = child_support_link_match[1]
       group_match = group_match[1]
-      return true unless Rails.application.routes.url_helpers.edit_admin_child_support_url(id: @parent.current_child.child_support_id).in?(child_support_link)
+      return true unless Rails.application.routes.url_helpers.edit_admin_child_support_url(id: @parent.current_child.child_support_id || '').in?(child_support_link)
 
       @parent.current_child.group_name != group_match
     end


### PR DESCRIPTION
Autoriser l'appel à l'update service même en l'absence de fiche de suivi pour être notifié des erreurs par la suite.