### PR TITLE
Fiche de suivi : Détecter les cas sans accompagnantes problématiques + refacto du clean de la fiche

### DIFF
--- a/app/admin/task.rb
+++ b/app/admin/task.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register Task do
     selectable_column
     id_column
     column :title do |model|
-      model.title_with_done_icon
+      link_to model.title_with_done_icon, admin_task_path(model)
     end
     column :due_date
     column :related, sortable: :related

--- a/app/jobs/child/handle_duplicate_job.rb
+++ b/app/jobs/child/handle_duplicate_job.rb
@@ -3,6 +3,7 @@ class Child
   class HandleDuplicateJob < ApplicationJob
     def perform
       Child::HandleDuplicateService.new.call
+      ChildSupport::DetectMissingSupporterService.new.call
     end
   end
 end

--- a/app/jobs/children_support_module/program_support_module_zero_job.rb
+++ b/app/jobs/children_support_module/program_support_module_zero_job.rb
@@ -4,6 +4,7 @@ class ChildrenSupportModule
 
     def perform(group_id, program_date)
       Child::HandleDuplicateService.new.call
+      ChildSupport::DetectMissingSupporterService.new.call
       ChildrenSupportModule::ProgramService.new.call(group_id, program_date, SupportModule::MODULE_ZERO_AGE_RANGE_LIST, SupportModule::LANGUAGE_MODULE_ZERO)
     end
   end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -809,14 +809,14 @@ class Child < ApplicationRecord
   def clean_child_support
     return if child_support.children.size == 1
 
-    child_support.children.find_each do |child|
-      next if child == self
+    other_children = child_support.children.where.not(id: id)
+    has_active_or_waiting = other_children.where(group_status: %w[waiting active]).exists?
 
-      return if child.group_status.in?(%w[waiting active])
+    # cleaning only if there is not active/waiting child in this child support
+    unless has_active_or_waiting
+      child_support.copy_fields(child_support)
+      child_support.clean_fields
+      child_support.save!
     end
-
-    child_support.copy_fields(child_support)
-    child_support.clean_fields
-    child_support.save!
   end
 end

--- a/app/models/child_support.rb
+++ b/app/models/child_support.rb
@@ -320,6 +320,17 @@ class ChildSupport < ApplicationRecord
       )"
     )
   }
+  scope :without_supporter_in_active_programmed_group, -> {
+    joins(children: :group)
+      .where(
+        children: { group_status: 'active', discarded_at: nil },
+        groups: { is_programmed: true, discarded_at: nil },
+        supporter_id: nil
+      )
+      .where('groups.ended_at IS NULL OR groups.ended_at > ?', Time.zone.today)
+      .distinct
+  }
+
 
   class << self
 
@@ -572,6 +583,7 @@ class ChildSupport < ApplicationRecord
   end
 
   def clean_fields
+    self.supporter_id = nil
     self.is_bilingual = '2_no_information'
     attributes.slice(
       'second_language',

--- a/app/services/child_support/detect_missing_supporter_service.rb
+++ b/app/services/child_support/detect_missing_supporter_service.rb
@@ -1,0 +1,36 @@
+class ChildSupport::DetectMissingSupporterService
+  def initialize
+    @child_support_link = {}
+    @child_supports_without_supporter = []
+  end
+
+  def call
+    @child_supports_without_supporter = ChildSupport.without_supporter_in_active_programmed_group.ids
+    @child_supports_without_supporter.each do |child_support_id|
+      create_child_support_link(child_support_id)
+    end
+
+    return self if @child_support_link.blank?
+
+    description_text = "Les fiches suivantes n'ont pas d'accompagnante alors qu'au moins un enfant doit être suivi :<br>"
+    @child_support_link.each { |name, link| description_text << "<br>#{ActionController::Base.helpers.link_to(name, link, target: '_blank', class: 'blue')}" }
+    Task::CreateAutomaticTaskService.new(
+      title: "Des fiches de suivi n'ont pas d'accompagnante",
+      description: description_text
+    ).call
+
+    Rollbar.error(
+      "Certaines fiches de suivi n'ont pas d'accompagnante",
+      child_supports: @child_supports_without_supporter,
+      source: 'ChildSupport::DetectMissingSupporterService'
+    )
+    self
+  end
+
+  private
+
+  def create_child_support_link(child_support_id)
+    link = Rails.application.routes.url_helpers.edit_admin_child_support_url(id: child_support_id)
+    @child_support_link[:"#{link}"] = link
+  end
+end

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -725,6 +725,7 @@ fr:
         title: Intitulé
         treated_by: En cours de traitement par
         status: Statut
+        display_description: Description
       task/child_support_task_title:
         disable_one_twin_support: Désactiver l’accompagnement d’un des jumeaux, pour qu’il n’y ait plus qu’un seul livre envoyé.
         remove_duplicate_child: Supprimer un doublon pour un même enfant accompagné


### PR DESCRIPTION
https://www.notion.so/Safety-net-pour-la-fonctionnalit-nettoyage-d-une-fiche-de-suivi-tape-1-240f8cee65b580b6bcf8e9e0dd567a94?source=copy_link