### PR TITLE
Dans tous les formulaires, modifier le libellé du champ “complément d’adresse” et ajouter un placeholder

### DIFF
--- a/app/helpers/addresses_helper.rb
+++ b/app/helpers/addresses_helper.rb
@@ -34,9 +34,10 @@ module AddressesHelper
   def address_address_supplement_input(form, prefix)
     form.input "#{prefix}address_supplement".to_sym,
       as: :string,
-      label: "Complément d'adresse",
+      label: "Important : précisions pour aider le livreur",
       input_html: {
-        id: "address-#{prefix}address_supplement".to_sym
+        id: "address-#{prefix}address_supplement".to_sym,
+        placeholder: 'Ex : bâtiment, résidence, interphone, appartement, porte, numéro de boîte...'
       }
   end
 


### PR DESCRIPTION
https://www.notion.so/2f2fb1db10c1484094d4d75a90b182bc?v=7b8f6783bbf24bf3bae3f474a4b9a9cf&p=1fbf8cee65b58042b4d9e3e197e3b104&pm=s